### PR TITLE
Add Cloud Agent environment configuration

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "taskboard",
+  "install": "rustup component add rustfmt clippy\n[ ! -f Cargo.toml ] || cargo fetch\n[ ! -f pnpm-lock.yaml ] || pnpm install --frozen-lockfile\n[ -f pnpm-lock.yaml ] || [ ! -f package.json ] || pnpm install"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a repository-managed Cloud Agent environment so install is versioned with the code.

## What this does

- Adds `.cursor/environment.json` with an idempotent `install` that:
  - ensures `rustfmt` and `clippy`
  - runs `cargo fetch` when `Cargo.toml` exists
  - runs `pnpm install` when a JS lockfile or `package.json` exists
- No `start` command yet: the repo is still design-only (`README` + spec), with no `tb serve` or desktop app to launch.

## Validation already done on this install

| Check | Result |
| --- | --- |
| Install ran twice | Succeeded both times |
| Rust hello-world | Compiled and ran |
| SQLite write/read | Succeeded |
| Node 22 | Succeeded |
| Draft environment build | `bld-20260905-fa60e641-06c9-48b3-b934-2bb85ce6ae12` succeeded |
| Fresh Cloud Agent | rustc 1.83, Node 22, webkit2gtk-4.1, install re-run exit 0 |

## Notes

After merge, this file is the environment source for Cloud Agents on this revision. The personal dashboard environment remains until this lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c47285e2-552b-4b30-aebe-160d80cb7867?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c47285e2-552b-4b30-aebe-160d80cb7867&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

