### PR TITLE
feat: add application errors and Store trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1007,7 +1018,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1422,7 +1433,12 @@ dependencies = [
 name = "taskboard-application"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "chrono",
+ "serde_json",
  "taskboard-core",
+ "thiserror 2.0.20",
+ "uuid",
 ]
 
 [[package]]
@@ -1467,7 +1483,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 rust-version = "1.83"
 
 [workspace.dependencies]
+async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -5,4 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait.workspace = true
+chrono.workspace = true
+serde_json.workspace = true
 taskboard-core = { path = "../core" }
+thiserror.workspace = true
+uuid.workspace = true

--- a/crates/application/src/actor.rs
+++ b/crates/application/src/actor.rs
@@ -1,0 +1,7 @@
+use taskboard_core::ActorKind;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Actor {
+    pub kind: ActorKind,
+    pub label: String,
+}

--- a/crates/application/src/commands.rs
+++ b/crates/application/src/commands.rs
@@ -1,0 +1,75 @@
+use taskboard_core::{Column, LinkKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectAdd {
+    pub name: String,
+    pub repo_path: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectUpdate {
+    pub slug: String,
+    pub name: Option<String>,
+    pub repo_path: Option<String>,
+    pub new_slug: Option<String>,
+    pub revision: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskCreate {
+    pub project_slug: String,
+    pub title: String,
+    pub column: Option<Column>,
+    pub urgent: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskUpdate {
+    pub display_id: String,
+    pub title: Option<String>,
+    pub revision: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkAdd {
+    pub task_display_id: String,
+    pub kind: LinkKind,
+    pub value: String,
+    pub revision: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunStart {
+    pub task_display_id: String,
+    pub agent: String,
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunUpdate {
+    pub run_display_id: String,
+    pub message: Option<String>,
+    pub revision: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunWait {
+    pub run_display_id: String,
+    pub reason: String,
+    pub revision: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunFail {
+    pub run_display_id: String,
+    pub summary: String,
+    pub revision: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunFinish {
+    pub run_display_id: String,
+    pub summary: String,
+    pub revision: Option<i64>,
+}

--- a/crates/application/src/error.rs
+++ b/crates/application/src/error.rs
@@ -1,0 +1,103 @@
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum AppError {
+    #[error("{message}")]
+    Validation { field: String, message: String },
+    #[error("{entity} {id} not found")]
+    NotFound { entity: String, id: String },
+    #[error("slug `{slug}` already exists")]
+    DuplicateSlug { slug: String },
+    #[error("revision conflict")]
+    RevisionConflict { current: serde_json::Value },
+    #[error("cannot reorder across columns {left} and {right}")]
+    DifferentColumn { left: String, right: String },
+    #[error("undo conflict")]
+    UndoConflict { current: serde_json::Value },
+    #[error("database busy")]
+    DatabaseBusy,
+    #[error("{0}")]
+    Io(String),
+}
+
+impl AppError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            AppError::Validation { .. } => "validation_error",
+            AppError::NotFound { .. } => "not_found",
+            AppError::DuplicateSlug { .. } => "duplicate_slug",
+            AppError::RevisionConflict { .. } => "revision_conflict",
+            AppError::DifferentColumn { .. } => "different_column",
+            AppError::UndoConflict { .. } => "undo_conflict",
+            AppError::DatabaseBusy => "database_busy",
+            AppError::Io(_) => "io_error",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppError;
+
+    #[test]
+    fn revision_conflict_code() {
+        let err = AppError::RevisionConflict {
+            current: serde_json::json!({}),
+        };
+        assert_eq!(err.code(), "revision_conflict");
+    }
+
+    #[test]
+    fn validation_code() {
+        let err = AppError::Validation {
+            field: "title".into(),
+            message: "must not be empty".into(),
+        };
+        assert_eq!(err.code(), "validation_error");
+    }
+
+    #[test]
+    fn not_found_code() {
+        let err = AppError::NotFound {
+            entity: "task".into(),
+            id: "TASK-1".into(),
+        };
+        assert_eq!(err.code(), "not_found");
+    }
+
+    #[test]
+    fn duplicate_slug_code() {
+        let err = AppError::DuplicateSlug {
+            slug: "renai-sim".into(),
+        };
+        assert_eq!(err.code(), "duplicate_slug");
+    }
+
+    #[test]
+    fn different_column_code() {
+        let err = AppError::DifferentColumn {
+            left: "todo".into(),
+            right: "done".into(),
+        };
+        assert_eq!(err.code(), "different_column");
+    }
+
+    #[test]
+    fn undo_conflict_code() {
+        let err = AppError::UndoConflict {
+            current: serde_json::json!({}),
+        };
+        assert_eq!(err.code(), "undo_conflict");
+    }
+
+    #[test]
+    fn database_busy_code() {
+        assert_eq!(AppError::DatabaseBusy.code(), "database_busy");
+    }
+
+    #[test]
+    fn io_code() {
+        let err = AppError::Io("disk full".into());
+        assert_eq!(err.code(), "io_error");
+    }
+}

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1,0 +1,12 @@
+mod actor;
+mod commands;
+mod error;
+mod store;
+
+pub use actor::Actor;
+pub use commands::{
+    LinkAdd, ProjectAdd, ProjectUpdate, RunFail, RunFinish, RunStart, RunUpdate, RunWait,
+    TaskCreate, TaskUpdate,
+};
+pub use error::AppError;
+pub use store::{NewActivity, Store, SyncDelta, Trash, UndoResult};

--- a/crates/application/src/store.rs
+++ b/crates/application/src/store.rs
@@ -1,0 +1,139 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use taskboard_core::{
+    Activity, ActorKind, Column, EntityType, Link, Project, Run, Task, TaskDetail, TaskSummary,
+};
+use uuid::Uuid;
+
+use crate::error::AppError;
+
+/// Row used to insert into `activities`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NewActivity {
+    pub id: Uuid,
+    pub sequence: i64,
+    pub actor_kind: ActorKind,
+    pub actor_label: String,
+    pub operation: String,
+    pub entity_type: EntityType,
+    pub entity_id: Uuid,
+    pub previous_revision: Option<i64>,
+    pub before_json: Option<serde_json::Value>,
+    pub after_json: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Trash {
+    pub projects: Vec<Project>,
+    pub tasks: Vec<TaskSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncDelta {
+    pub sequence: i64,
+    pub projects: Vec<Project>,
+    pub tasks: Vec<TaskDetail>,
+    pub runs: Vec<Run>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UndoResult {
+    pub entity_type: EntityType,
+    pub entity: serde_json::Value,
+}
+
+/// Persistence surface implemented by `taskboard-store-sqlite`.
+///
+/// Get/list/insert/update (and soft-delete/restore where the schema supports it)
+/// cover projects, tasks, links, and runs so later use cases can land without
+/// rewriting this trait. Links and runs have no `deleted_at`; they are hard-deleted.
+#[async_trait]
+pub trait Store: Send + Sync {
+    async fn next_display_n(&mut self, counter: &str) -> Result<i64, AppError>;
+    async fn next_activity_sequence(&mut self) -> Result<i64, AppError>;
+    async fn insert_activity(&mut self, row: NewActivity) -> Result<(), AppError>;
+
+    async fn get_project(&mut self, id: Uuid) -> Result<Option<Project>, AppError>;
+    async fn get_project_by_slug(
+        &mut self,
+        slug: &str,
+        include_deleted: bool,
+    ) -> Result<Option<Project>, AppError>;
+    async fn list_projects(&mut self, include_archived: bool) -> Result<Vec<Project>, AppError>;
+    async fn list_deleted_projects(&mut self) -> Result<Vec<Project>, AppError>;
+    async fn insert_project(&mut self, project: &Project) -> Result<(), AppError>;
+    async fn update_project(&mut self, project: &Project) -> Result<(), AppError>;
+    async fn soft_delete_project(
+        &mut self,
+        id: Uuid,
+        deleted_at: DateTime<Utc>,
+    ) -> Result<(), AppError>;
+    async fn restore_project(&mut self, id: Uuid) -> Result<(), AppError>;
+    async fn rewrite_project_sort_orders(&mut self, ordered_ids: &[Uuid]) -> Result<(), AppError>;
+
+    async fn get_task(&mut self, id: Uuid) -> Result<Option<Task>, AppError>;
+    async fn get_task_by_display_id(
+        &mut self,
+        display_id: &str,
+        include_deleted: bool,
+    ) -> Result<Option<Task>, AppError>;
+    async fn list_tasks(&mut self, project_id: Uuid) -> Result<Vec<Task>, AppError>;
+    async fn list_deleted_tasks(&mut self) -> Result<Vec<Task>, AppError>;
+    async fn insert_task(&mut self, task: &Task) -> Result<(), AppError>;
+    async fn update_task(&mut self, task: &Task) -> Result<(), AppError>;
+    async fn soft_delete_task(
+        &mut self,
+        id: Uuid,
+        deleted_at: DateTime<Utc>,
+    ) -> Result<(), AppError>;
+    async fn restore_task(&mut self, id: Uuid) -> Result<(), AppError>;
+
+    /// Rewrite live task positions in `column` to `0..n-1` following `ordered_ids`.
+    ///
+    /// The SQLite implementation must use two phases to satisfy the unique
+    /// live-position index: first set `position = -(old_position + 1)` for each
+    /// affected row, then assign the final `0..n-1` values.
+    async fn rewrite_task_positions(
+        &mut self,
+        project_id: Uuid,
+        column: Column,
+        ordered_ids: &[Uuid],
+    ) -> Result<(), AppError>;
+
+    async fn get_link(&mut self, id: Uuid) -> Result<Option<Link>, AppError>;
+    async fn list_links(&mut self, task_id: Uuid) -> Result<Vec<Link>, AppError>;
+    async fn insert_link(&mut self, link: &Link) -> Result<(), AppError>;
+    async fn update_link(&mut self, link: &Link) -> Result<(), AppError>;
+    async fn delete_link(&mut self, id: Uuid) -> Result<(), AppError>;
+
+    async fn get_run(&mut self, id: Uuid) -> Result<Option<Run>, AppError>;
+    async fn get_run_by_display_id(&mut self, display_id: &str) -> Result<Option<Run>, AppError>;
+    async fn list_runs(&mut self, task_id: Uuid) -> Result<Vec<Run>, AppError>;
+    async fn insert_run(&mut self, run: &Run) -> Result<(), AppError>;
+    async fn update_run(&mut self, run: &Run) -> Result<(), AppError>;
+    async fn delete_run(&mut self, id: Uuid) -> Result<(), AppError>;
+
+    async fn activity_head(&mut self) -> Result<i64, AppError>;
+    async fn latest_activity_for(&mut self, entity_id: Uuid) -> Result<Option<Activity>, AppError>;
+    async fn latest_undoable(&mut self) -> Result<Option<Activity>, AppError>;
+    async fn list_activities_after(&mut self, sequence: i64) -> Result<Vec<Activity>, AppError>;
+    async fn list_recent_activities(
+        &mut self,
+        entity_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<Activity>, AppError>;
+
+    async fn purge_expired(
+        &mut self,
+        now: DateTime<Utc>,
+        retention_days: i64,
+    ) -> Result<u64, AppError>;
+    async fn backup_to(&mut self, dest: &Path) -> Result<(), AppError>;
+    async fn replace_from(&mut self, src: &Path) -> Result<(), AppError>;
+    async fn begin(&mut self) -> Result<(), AppError>;
+    async fn commit(&mut self) -> Result<(), AppError>;
+    async fn rollback(&mut self) -> Result<(), AppError>;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7

Plan 1 Task 5: `AppError` codes, `Actor`, command DTOs, and the `Store` trait (including two-phase `rewrite_task_positions` contract). No SQLite implementation yet.

Verify: `cargo test -p taskboard-application` (8 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

