### PR TITLE
feat: open SQLite database and apply initial schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,23 +1476,27 @@ dependencies = [
 name = "taskboard-store-sqlite"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "serde",
  "sqlx",
  "taskboard-application",
  "taskboard-core",
+ "tempfile",
  "tokio",
+ "toml",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1577,6 +1590,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1983,6 +2037,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/store-sqlite/Cargo.toml
+++ b/crates/store-sqlite/Cargo.toml
@@ -7,5 +7,11 @@ license.workspace = true
 [dependencies]
 taskboard-application = { path = "../application" }
 taskboard-core = { path = "../core" }
+chrono.workspace = true
+serde.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
+toml = "=0.8.23"
+
+[dev-dependencies]
+tempfile = "=3.19.1"

--- a/crates/store-sqlite/migrations/0001_init.sql
+++ b/crates/store-sqlite/migrations/0001_init.sql
@@ -1,0 +1,84 @@
+CREATE TABLE counters (
+    name TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+
+INSERT INTO counters (name, value) VALUES ('task', 0), ('run', 0), ('activity', 0);
+
+CREATE TABLE projects (
+    id BLOB NOT NULL PRIMARY KEY,
+    slug TEXT NOT NULL,
+    name TEXT NOT NULL,
+    repo_path TEXT,
+    archived INTEGER NOT NULL DEFAULT 0,
+    note_markdown TEXT NOT NULL DEFAULT '',
+    sort_order INTEGER NOT NULL,
+    revision INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+
+CREATE UNIQUE INDEX idx_projects_live_slug
+    ON projects (slug)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE tasks (
+    id BLOB NOT NULL PRIMARY KEY,
+    display_id TEXT NOT NULL UNIQUE,
+    project_id BLOB NOT NULL REFERENCES projects (id),
+    title TEXT NOT NULL,
+    column TEXT NOT NULL,
+    urgent INTEGER NOT NULL DEFAULT 0,
+    note_markdown TEXT NOT NULL DEFAULT '',
+    position INTEGER NOT NULL,
+    revision INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+
+CREATE UNIQUE INDEX idx_tasks_live_position
+    ON tasks (project_id, column, position)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE links (
+    id BLOB NOT NULL PRIMARY KEY,
+    task_id BLOB NOT NULL REFERENCES tasks (id),
+    kind TEXT NOT NULL,
+    value TEXT NOT NULL,
+    sort_order INTEGER NOT NULL
+);
+
+CREATE TABLE runs (
+    id BLOB NOT NULL PRIMARY KEY,
+    display_id TEXT NOT NULL UNIQUE,
+    task_id BLOB NOT NULL REFERENCES tasks (id),
+    agent TEXT NOT NULL,
+    session_id TEXT,
+    status TEXT NOT NULL,
+    message TEXT,
+    waiting_reason TEXT,
+    summary TEXT,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    revision INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE activities (
+    id BLOB NOT NULL PRIMARY KEY,
+    sequence INTEGER NOT NULL UNIQUE,
+    actor_kind TEXT NOT NULL,
+    actor_label TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id BLOB NOT NULL,
+    previous_revision INTEGER,
+    before_json TEXT,
+    after_json TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_activities_entity ON activities (entity_id, sequence);

--- a/crates/store-sqlite/src/config.rs
+++ b/crates/store-sqlite/src/config.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub log_level: String,
+    pub poll_interval_ms: u64,
+    pub note_debounce_ms: u64,
+    pub backup_retention: u32,
+    pub busy_timeout_ms: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            log_level: "info".to_owned(),
+            poll_interval_ms: 1000,
+            note_debounce_ms: 400,
+            backup_retention: 30,
+            busy_timeout_ms: 5000,
+        }
+    }
+}
+
+/// Reads `{data_dir}/config.toml`. A missing file uses defaults; unknown keys are ignored.
+pub fn load_config(data_dir: &Path) -> Config {
+    let path = data_dir.join("config.toml");
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Config::default();
+    };
+    toml::from_str(&text).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_config_uses_defaults() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = load_config(tmp.path());
+        assert_eq!(cfg.poll_interval_ms, 1000);
+        assert_eq!(cfg.note_debounce_ms, 400);
+        assert_eq!(cfg.backup_retention, 30);
+        assert_eq!(cfg.busy_timeout_ms, 5000);
+    }
+
+    #[test]
+    fn config_ignores_unknown_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("config.toml"),
+            "log_level = \"debug\"\nunknown = 1\n",
+        )
+        .unwrap();
+        let cfg = load_config(tmp.path());
+        assert_eq!(cfg.log_level, "debug");
+    }
+
+    #[test]
+    fn missing_config_default_log_level_is_info() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = load_config(tmp.path());
+        assert_eq!(cfg.log_level, "info");
+    }
+}

--- a/crates/store-sqlite/src/db.rs
+++ b/crates/store-sqlite/src/db.rs
@@ -40,10 +40,7 @@ pub async fn open_db(data_dir: &Path) -> Result<SqlitePool, AppError> {
         if db_existed {
             backup_pre_migration(data_dir, &pool).await?;
         }
-        sqlx::raw_sql(INIT_SQL)
-            .execute(&pool)
-            .await
-            .map_err(map_sqlx)?;
+        apply_init_migration(&pool).await?;
         write_log(
             &log_path,
             &cfg.log_level,
@@ -53,6 +50,16 @@ pub async fn open_db(data_dir: &Path) -> Result<SqlitePool, AppError> {
     }
 
     Ok(pool)
+}
+
+async fn apply_init_migration(pool: &SqlitePool) -> Result<(), AppError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx)?;
+    sqlx::raw_sql(INIT_SQL)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx)?;
+    tx.commit().await.map_err(map_sqlx)?;
+    Ok(())
 }
 
 async fn projects_table_exists(pool: &SqlitePool) -> Result<bool, AppError> {
@@ -90,7 +97,10 @@ fn create_log_file(logs_dir: &Path) -> Result<PathBuf, AppError> {
 
 fn write_log(path: &Path, configured_level: &str, message_level: &str, message: &str) {
     // Diagnostic logs must never include note bodies, run summaries, or repository paths.
-    if message.contains("note_markdown") || message.contains("repo_path") {
+    if message.contains("note_markdown")
+        || message.contains("repo_path")
+        || message.contains("summary")
+    {
         return;
     }
     if !log_enabled(configured_level, message_level) {
@@ -234,5 +244,75 @@ mod tests {
     #[test]
     fn init_sql_matches_migrations_file() {
         assert_eq!(INIT_SQL, include_str!("../migrations/0001_init.sql"));
+    }
+
+    #[tokio::test]
+    async fn open_db_applies_full_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = open_db(tmp.path()).await.unwrap();
+        let tables: Vec<String> = sqlx::query_scalar(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            tables,
+            [
+                "activities",
+                "counters",
+                "links",
+                "projects",
+                "runs",
+                "tasks",
+            ]
+        );
+        pool.close().await;
+    }
+
+    /// `apply_init_migration` runs `INIT_SQL` inside a sqlx transaction so a failed
+    /// statement rolls back the entire script instead of leaving partial schema.
+    #[tokio::test]
+    async fn failed_statement_inside_transaction_does_not_commit_partial_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("test.sqlite3");
+        let pool = SqlitePool::connect_with(
+            SqliteConnectOptions::new()
+                .filename(&db)
+                .create_if_missing(true),
+        )
+        .await
+        .unwrap();
+
+        let mut tx = pool.begin().await.unwrap();
+        let broken = "CREATE TABLE counters (name TEXT PRIMARY KEY);\nNOT VALID SQL;";
+        let result = sqlx::raw_sql(broken).execute(&mut *tx).await;
+        assert!(result.is_err());
+        tx.rollback().await.unwrap();
+
+        let counters: Option<String> = sqlx::query_scalar(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'counters'",
+        )
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert!(counters.is_none());
+        pool.close().await;
+    }
+
+    #[test]
+    fn write_log_skips_forbidden_substrings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log_path = tmp.path().join("taskboard.log");
+        write_log(&log_path, "info", "info", "safe message");
+        write_log(&log_path, "info", "info", "contains note_markdown field");
+        write_log(&log_path, "info", "info", "contains repo_path field");
+        write_log(&log_path, "info", "info", "contains summary field");
+
+        let contents = fs::read_to_string(&log_path).unwrap();
+        assert!(contents.contains("safe message"));
+        assert!(!contents.contains("note_markdown"));
+        assert!(!contents.contains("repo_path"));
+        assert!(!contents.contains("summary field"));
     }
 }

--- a/crates/store-sqlite/src/db.rs
+++ b/crates/store-sqlite/src/db.rs
@@ -1,0 +1,238 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::Utc;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+use sqlx::SqlitePool;
+use taskboard_application::AppError;
+
+use crate::config::load_config;
+use crate::migrations::INIT_SQL;
+
+/// Opens `{data_dir}/taskboard.sqlite3`, applying `0001_init.sql` when `projects` is missing.
+pub async fn open_db(data_dir: &Path) -> Result<SqlitePool, AppError> {
+    fs::create_dir_all(data_dir).map_err(map_io)?;
+    let logs_dir = data_dir.join("logs");
+    fs::create_dir_all(&logs_dir).map_err(map_io)?;
+    let log_path = create_log_file(&logs_dir)?;
+
+    let cfg = load_config(data_dir);
+    write_log(&log_path, &cfg.log_level, "info", "opening database");
+
+    let db_path = data_dir.join("taskboard.sqlite3");
+    let db_existed = db_path.exists();
+
+    let options = SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .foreign_keys(true)
+        .busy_timeout(Duration::from_millis(cfg.busy_timeout_ms));
+
+    let pool = SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .map_err(map_sqlx)?;
+
+    if !projects_table_exists(&pool).await? {
+        if db_existed {
+            backup_pre_migration(data_dir, &pool).await?;
+        }
+        sqlx::raw_sql(INIT_SQL)
+            .execute(&pool)
+            .await
+            .map_err(map_sqlx)?;
+        write_log(
+            &log_path,
+            &cfg.log_level,
+            "info",
+            "applied migration 0001_init",
+        );
+    }
+
+    Ok(pool)
+}
+
+async fn projects_table_exists(pool: &SqlitePool) -> Result<bool, AppError> {
+    let name: Option<String> = sqlx::query_scalar(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'projects'",
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(map_sqlx)?;
+    Ok(name.is_some())
+}
+
+async fn backup_pre_migration(data_dir: &Path, pool: &SqlitePool) -> Result<(), AppError> {
+    let backups = data_dir.join("backups");
+    fs::create_dir_all(&backups).map_err(map_io)?;
+    let stamp = Utc::now().format("%Y%m%dT%H%M%SZ");
+    let dest = backups.join(format!("pre-migration-0001-{stamp}.sqlite3"));
+    let dest_sql = dest.to_string_lossy().replace('\'', "''");
+    sqlx::query(&format!("VACUUM INTO '{dest_sql}'"))
+        .execute(pool)
+        .await
+        .map_err(map_sqlx)?;
+    Ok(())
+}
+
+fn create_log_file(logs_dir: &Path) -> Result<PathBuf, AppError> {
+    let path = logs_dir.join("taskboard.log");
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(map_io)?;
+    Ok(path)
+}
+
+fn write_log(path: &Path, configured_level: &str, message_level: &str, message: &str) {
+    // Diagnostic logs must never include note bodies, run summaries, or repository paths.
+    if message.contains("note_markdown") || message.contains("repo_path") {
+        return;
+    }
+    if !log_enabled(configured_level, message_level) {
+        return;
+    }
+    let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
+        return;
+    };
+    let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let _ = writeln!(file, "{ts} {message_level} {message}");
+}
+
+fn log_enabled(configured: &str, message_level: &str) -> bool {
+    rank(message_level) <= rank(configured)
+}
+
+fn rank(level: &str) -> u8 {
+    match level {
+        "error" => 1,
+        "warn" => 2,
+        "info" => 3,
+        "debug" => 4,
+        _ => 3,
+    }
+}
+
+fn map_io(err: std::io::Error) -> AppError {
+    AppError::Io(err.to_string())
+}
+
+fn map_sqlx(err: sqlx::Error) -> AppError {
+    if let sqlx::Error::Database(db_err) = &err {
+        let code = db_err.code();
+        if matches!(code.as_deref(), Some("5" | "6")) {
+            return AppError::DatabaseBusy;
+        }
+        let msg = db_err.message();
+        if msg.contains("database is locked") || msg.contains("database is busy") {
+            return AppError::DatabaseBusy;
+        }
+    }
+    AppError::Io(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn open_db_creates_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = open_db(tmp.path()).await.unwrap();
+        let n: i64 = sqlx::query_scalar("select count(*) from counters")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 3);
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn open_db_creates_log_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = open_db(tmp.path()).await.unwrap();
+        assert!(tmp.path().join("logs/taskboard.log").is_file());
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn open_db_enables_wal_and_foreign_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = open_db(tmp.path()).await.unwrap();
+        let mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(mode.to_lowercase(), "wal");
+        let fk: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(fk, 1);
+        let timeout: i64 = sqlx::query_scalar("PRAGMA busy_timeout")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(timeout, 5000);
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn open_db_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = open_db(tmp.path()).await.unwrap();
+        pool.close().await;
+        let pool = open_db(tmp.path()).await.unwrap();
+        let n: i64 = sqlx::query_scalar("select count(*) from counters")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 3);
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn first_open_skips_pre_migration_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = open_db(tmp.path()).await.unwrap();
+        pool.close().await;
+        let backups = tmp.path().join("backups");
+        assert!(!backups.exists() || fs::read_dir(&backups).unwrap().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn open_db_backs_up_existing_db_before_0001() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("taskboard.sqlite3");
+        {
+            let options = SqliteConnectOptions::new()
+                .filename(&db)
+                .create_if_missing(true);
+            let pool = SqlitePool::connect_with(options).await.unwrap();
+            sqlx::query("CREATE TABLE leftover (id INTEGER PRIMARY KEY)")
+                .execute(&pool)
+                .await
+                .unwrap();
+            pool.close().await;
+        }
+        let pool = open_db(tmp.path()).await.unwrap();
+        pool.close().await;
+        let backups = tmp.path().join("backups");
+        let entries: Vec<_> = fs::read_dir(&backups)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].starts_with("pre-migration-0001-"));
+        assert!(entries[0].ends_with(".sqlite3"));
+    }
+
+    #[test]
+    fn init_sql_matches_migrations_file() {
+        assert_eq!(INIT_SQL, include_str!("../migrations/0001_init.sql"));
+    }
+}

--- a/crates/store-sqlite/src/lib.rs
+++ b/crates/store-sqlite/src/lib.rs
@@ -1,0 +1,9 @@
+mod config;
+mod db;
+mod migrations;
+mod paths;
+
+pub use config::{load_config, Config};
+pub use db::open_db;
+pub use migrations::INIT_SQL;
+pub use paths::{default_data_dir, resolve_data_dir};

--- a/crates/store-sqlite/src/migrations.rs
+++ b/crates/store-sqlite/src/migrations.rs
@@ -1,0 +1,1 @@
+pub const INIT_SQL: &str = include_str!("../migrations/0001_init.sql");

--- a/crates/store-sqlite/src/paths.rs
+++ b/crates/store-sqlite/src/paths.rs
@@ -1,0 +1,75 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+pub fn default_data_dir() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        return home_dir().join("Library/Application Support/Taskboard");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+            if !xdg.is_empty() {
+                return PathBuf::from(xdg).join("taskboard");
+            }
+        }
+        home_dir().join(".local/share/taskboard")
+    }
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"))
+}
+
+/// CLI override wins, then `TASKBOARD_DATA_DIR`, then the platform default.
+pub fn resolve_data_dir(cli_override: Option<&Path>, env: Option<&OsStr>) -> PathBuf {
+    if let Some(cli) = cli_override {
+        return cli.to_path_buf();
+    }
+    if let Some(env_dir) = env {
+        return PathBuf::from(env_dir);
+    }
+    default_data_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn cli_override_wins() {
+        let dir = resolve_data_dir(
+            Some(Path::new("/tmp/tb-cli")),
+            Some(OsStr::new("/tmp/tb-env")),
+        );
+        assert_eq!(dir, Path::new("/tmp/tb-cli"));
+    }
+
+    #[test]
+    fn env_override_used_when_cli_absent() {
+        let dir = resolve_data_dir(None, Some(OsStr::new("/tmp/tb-env")));
+        assert_eq!(dir, Path::new("/tmp/tb-env"));
+    }
+
+    #[test]
+    fn default_used_when_cli_and_env_absent() {
+        let dir = resolve_data_dir(None, None);
+        assert_eq!(dir, default_data_dir());
+    }
+
+    #[test]
+    fn default_data_dir_linux_uses_xdg_or_local_share() {
+        let dir = default_data_dir();
+        if let Some(xdg) = std::env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty()) {
+            assert_eq!(dir, PathBuf::from(xdg).join("taskboard"));
+        } else {
+            assert_eq!(dir, home_dir().join(".local/share/taskboard"));
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8

Plan 1 Task 6: data directory resolution, `config.toml` defaults, WAL SQLite, and migration `0001_init.sql` applied in a transaction.

Verify: `cargo test -p taskboard-store-sqlite` (17 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

