### PR TITLE
feat: add project use cases and sqlite persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,9 +1444,13 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "serde",
  "serde_json",
  "taskboard-core",
+ "taskboard-store-sqlite",
+ "tempfile",
  "thiserror 2.0.20",
+ "tokio",
  "uuid",
 ]
 
@@ -1476,14 +1480,17 @@ dependencies = [
 name = "taskboard-store-sqlite"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "serde",
+ "serde_json",
  "sqlx",
  "taskboard-application",
  "taskboard-core",
  "tempfile",
  "tokio",
  "toml",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -7,7 +7,13 @@ license.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 taskboard-core = { path = "../core" }
 thiserror.workspace = true
+tokio.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tempfile = "=3.19.1"
+taskboard-store-sqlite = { path = "../store-sqlite" }

--- a/crates/application/src/app.rs
+++ b/crates/application/src/app.rs
@@ -1,0 +1,556 @@
+use chrono::{DateTime, Utc};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use taskboard_core::{
+    next_unique_slug, slugify, trim_project_name, EntityType, FieldError, Project, SlugError,
+    ValidationError,
+};
+
+use crate::actor::Actor;
+use crate::commands::{ProjectAdd, ProjectUpdate};
+use crate::error::AppError;
+use crate::store::{NewActivity, Store};
+
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+pub struct App {
+    store: Mutex<Box<dyn Store>>,
+    clock: Box<dyn Clock>,
+}
+
+impl App {
+    pub fn new(store: impl Store + 'static, clock: impl Clock + 'static) -> Self {
+        Self {
+            store: Mutex::new(Box::new(store)),
+            clock: Box::new(clock),
+        }
+    }
+
+    pub async fn project_add(&self, actor: &Actor, cmd: ProjectAdd) -> Result<Project, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = project_add_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn project_list(&self, include_archived: bool) -> Result<Vec<Project>, AppError> {
+        let mut store = self.store.lock().await;
+        store.list_projects(include_archived).await
+    }
+
+    pub async fn project_show(&self, slug: &str) -> Result<Project, AppError> {
+        let mut store = self.store.lock().await;
+        require_live_project(&mut **store, slug).await
+    }
+
+    pub async fn project_update(
+        &self,
+        actor: &Actor,
+        cmd: ProjectUpdate,
+    ) -> Result<Project, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = project_update_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn project_reorder(
+        &self,
+        actor: &Actor,
+        slugs_in_order: &[String],
+    ) -> Result<Vec<Project>, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = project_reorder_inner(store, actor, slugs_in_order, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn project_archive(
+        &self,
+        actor: &Actor,
+        slug: &str,
+        archived: bool,
+        revision: Option<i64>,
+    ) -> Result<Project, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = project_archive_inner(store, actor, slug, archived, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn project_delete(
+        &self,
+        actor: &Actor,
+        slug: &str,
+        revision: Option<i64>,
+    ) -> Result<Project, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = project_delete_inner(store, actor, slug, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn project_restore(&self, actor: &Actor, slug: &str) -> Result<Project, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = project_restore_inner(store, actor, slug, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn project_note_set(
+        &self,
+        actor: &Actor,
+        slug: &str,
+        markdown: String,
+        revision: Option<i64>,
+    ) -> Result<Project, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = project_note_set_inner(store, actor, slug, markdown, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+}
+
+async fn commit_or_rollback<T>(
+    store: &mut dyn Store,
+    result: Result<T, AppError>,
+) -> Result<T, AppError> {
+    match result {
+        Ok(value) => match store.commit().await {
+            Ok(()) => Ok(value),
+            Err(err) => {
+                let _ = store.rollback().await;
+                Err(err)
+            }
+        },
+        Err(err) => {
+            let _ = store.rollback().await;
+            Err(err)
+        }
+    }
+}
+
+async fn project_add_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: ProjectAdd,
+    now: DateTime<Utc>,
+) -> Result<Project, AppError> {
+    let name = trim_project_name(&cmd.name).map_err(map_validation)?;
+    let live = store.list_projects(true).await?;
+    let slug = if let Some(explicit) = cmd.slug.as_deref() {
+        let slug = slugify_field("slug", explicit)?;
+        if live.iter().any(|project| project.slug == slug) {
+            return Err(AppError::DuplicateSlug { slug });
+        }
+        slug
+    } else {
+        let live_slugs: Vec<&str> = live.iter().map(|project| project.slug.as_str()).collect();
+        next_unique_slug(&name, &live_slugs).map_err(map_slug_error)?
+    };
+    let sort_order = live
+        .iter()
+        .map(|project| project.sort_order)
+        .max()
+        .map(|max| max + 1)
+        .unwrap_or(0);
+    let project = Project {
+        id: Uuid::now_v7(),
+        slug,
+        name,
+        repo_path: cmd.repo_path,
+        archived: false,
+        note_markdown: String::new(),
+        sort_order,
+        revision: 1,
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+    store.insert_project(&project).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            operation: "project.create",
+            entity_id: project.id,
+            previous_revision: None,
+            before_json: None,
+            after_json: Some(json_value(&project)?),
+        },
+    )
+    .await?;
+    Ok(project)
+}
+
+async fn project_update_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: ProjectUpdate,
+    now: DateTime<Utc>,
+) -> Result<Project, AppError> {
+    let mut project = require_live_project(store, &cmd.slug).await?;
+    check_revision(&project, cmd.revision)?;
+    let before = project.clone();
+    if let Some(name) = cmd.name {
+        project.name = trim_project_name(&name).map_err(map_validation)?;
+    }
+    if let Some(repo_path) = cmd.repo_path {
+        project.repo_path = if repo_path.is_empty() {
+            None
+        } else {
+            Some(repo_path)
+        };
+    }
+    if let Some(new_slug) = cmd.new_slug {
+        let new_slug = slugify_field("slug", &new_slug)?;
+        if new_slug != project.slug {
+            if store.get_project_by_slug(&new_slug, false).await?.is_some() {
+                return Err(AppError::DuplicateSlug { slug: new_slug });
+            }
+            project.slug = new_slug;
+        }
+    }
+    project.revision += 1;
+    project.updated_at = now;
+    store.update_project(&project).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            operation: "project.update",
+            entity_id: project.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&project)?),
+        },
+    )
+    .await?;
+    Ok(project)
+}
+
+async fn project_reorder_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    slugs_in_order: &[String],
+    now: DateTime<Utc>,
+) -> Result<Vec<Project>, AppError> {
+    let live = store.list_projects(true).await?;
+    if slugs_in_order.is_empty() && live.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut remaining: std::collections::HashMap<String, Project> = live
+        .into_iter()
+        .map(|project| (project.slug.clone(), project))
+        .collect();
+    let mut seen = std::collections::HashSet::new();
+    let mut ordered = Vec::with_capacity(slugs_in_order.len());
+    for slug in slugs_in_order {
+        if !seen.insert(slug) {
+            return Err(AppError::Validation {
+                field: "slugs".into(),
+                message: "duplicate slug in reorder list".into(),
+            });
+        }
+        let project = remaining.remove(slug).ok_or_else(|| AppError::NotFound {
+            entity: "project".into(),
+            id: slug.clone(),
+        })?;
+        ordered.push(project);
+    }
+    if !remaining.is_empty() {
+        return Err(AppError::Validation {
+            field: "slugs".into(),
+            message: "reorder list must cover all live projects".into(),
+        });
+    }
+    let before = ordered.clone();
+    let ids: Vec<Uuid> = ordered.iter().map(|project| project.id).collect();
+    store.rewrite_project_sort_orders(&ids).await?;
+    for (index, project) in ordered.iter_mut().enumerate() {
+        project.sort_order = index as i64;
+        project.revision += 1;
+        project.updated_at = now;
+        store.update_project(project).await?;
+    }
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            operation: "project.reorder",
+            entity_id: ordered[0].id,
+            previous_revision: None,
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&ordered)?),
+        },
+    )
+    .await?;
+    Ok(ordered)
+}
+
+async fn project_archive_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    slug: &str,
+    archived: bool,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<Project, AppError> {
+    let mut project = require_live_project(store, slug).await?;
+    check_revision(&project, revision)?;
+    let before = project.clone();
+    project.archived = archived;
+    project.revision += 1;
+    project.updated_at = now;
+    store.update_project(&project).await?;
+    let operation = if archived {
+        "project.archive"
+    } else {
+        "project.unarchive"
+    };
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            operation,
+            entity_id: project.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&project)?),
+        },
+    )
+    .await?;
+    Ok(project)
+}
+
+async fn project_delete_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    slug: &str,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<Project, AppError> {
+    let mut project = require_live_project(store, slug).await?;
+    check_revision(&project, revision)?;
+    let before = project.clone();
+    project.deleted_at = Some(now);
+    project.revision += 1;
+    project.updated_at = now;
+    store.update_project(&project).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            operation: "project.delete",
+            entity_id: project.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&project)?),
+        },
+    )
+    .await?;
+    Ok(project)
+}
+
+async fn project_restore_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    slug: &str,
+    now: DateTime<Utc>,
+) -> Result<Project, AppError> {
+    if store.get_project_by_slug(slug, false).await?.is_some() {
+        let has_deleted = store
+            .list_deleted_projects()
+            .await?
+            .iter()
+            .any(|project| project.slug == slug);
+        if has_deleted {
+            return Err(AppError::DuplicateSlug {
+                slug: slug.to_string(),
+            });
+        }
+        return Err(project_not_found(slug));
+    }
+    let mut matches: Vec<Project> = store
+        .list_deleted_projects()
+        .await?
+        .into_iter()
+        .filter(|project| project.slug == slug)
+        .collect();
+    matches.sort_by_key(|project| project.deleted_at);
+    let mut project = matches.pop().ok_or_else(|| project_not_found(slug))?;
+    let before = project.clone();
+    project.deleted_at = None;
+    project.revision += 1;
+    project.updated_at = now;
+    store.restore_project(project.id).await?;
+    store.update_project(&project).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            operation: "project.restore",
+            entity_id: project.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&project)?),
+        },
+    )
+    .await?;
+    Ok(project)
+}
+
+async fn project_note_set_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    slug: &str,
+    markdown: String,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<Project, AppError> {
+    let mut project = require_live_project(store, slug).await?;
+    check_revision(&project, revision)?;
+    let before = project.clone();
+    project.note_markdown = markdown;
+    project.revision += 1;
+    project.updated_at = now;
+    store.update_project(&project).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            operation: "project.note.set",
+            entity_id: project.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&project)?),
+        },
+    )
+    .await?;
+    Ok(project)
+}
+
+async fn require_live_project(store: &mut dyn Store, slug: &str) -> Result<Project, AppError> {
+    store
+        .get_project_by_slug(slug, false)
+        .await?
+        .ok_or_else(|| project_not_found(slug))
+}
+
+fn project_not_found(slug: &str) -> AppError {
+    AppError::NotFound {
+        entity: "project".into(),
+        id: slug.to_string(),
+    }
+}
+
+fn check_revision(project: &Project, expected: Option<i64>) -> Result<(), AppError> {
+    if let Some(expected) = expected {
+        if expected != project.revision {
+            return Err(AppError::RevisionConflict {
+                current: serde_json::to_value(project).map_err(map_json)?,
+            });
+        }
+    }
+    Ok(())
+}
+
+struct ActivityWrite {
+    operation: &'static str,
+    entity_id: Uuid,
+    previous_revision: Option<i64>,
+    before_json: Option<serde_json::Value>,
+    after_json: Option<serde_json::Value>,
+}
+
+async fn record_activity(
+    store: &mut dyn Store,
+    actor: &Actor,
+    now: DateTime<Utc>,
+    write: ActivityWrite,
+) -> Result<(), AppError> {
+    let sequence = store.next_activity_sequence().await?;
+    store
+        .insert_activity(NewActivity {
+            id: Uuid::now_v7(),
+            sequence,
+            actor_kind: actor.kind,
+            actor_label: actor.label.clone(),
+            operation: write.operation.to_string(),
+            entity_type: EntityType::Project,
+            entity_id: write.entity_id,
+            previous_revision: write.previous_revision,
+            before_json: write.before_json,
+            after_json: write.after_json,
+            created_at: now,
+        })
+        .await
+}
+
+fn json_value<T: serde::Serialize>(value: &T) -> Result<serde_json::Value, AppError> {
+    serde_json::to_value(value).map_err(map_json)
+}
+
+fn slugify_field(field: &str, raw: &str) -> Result<String, AppError> {
+    slugify(raw).map_err(|_| AppError::Validation {
+        field: field.to_string(),
+        message: "must be a valid slug".into(),
+    })
+}
+
+fn map_validation(err: ValidationError) -> AppError {
+    AppError::Validation {
+        field: err.field.to_string(),
+        message: match err.source {
+            FieldError::Empty => "must not be empty".into(),
+            FieldError::TooLong { max } => format!("must be at most {max} characters"),
+            FieldError::Invalid { allowed } => format!("must be {allowed}"),
+        },
+    }
+}
+
+fn map_slug_error(err: SlugError) -> AppError {
+    match err {
+        SlugError::Empty => AppError::Validation {
+            field: "name".into(),
+            message: "cannot derive a slug".into(),
+        },
+    }
+}
+
+fn map_json(err: serde_json::Error) -> AppError {
+    AppError::Io(err.to_string())
+}

--- a/crates/application/src/app.rs
+++ b/crates/application/src/app.rs
@@ -411,6 +411,13 @@ async fn project_restore_inner(
     matches.sort_by_key(|project| project.deleted_at);
     let mut project = matches.pop().ok_or_else(|| project_not_found(slug))?;
     let before = project.clone();
+    let live = store.list_projects(true).await?;
+    project.sort_order = live
+        .iter()
+        .map(|live_project| live_project.sort_order)
+        .max()
+        .map(|max| max + 1)
+        .unwrap_or(0);
     project.deleted_at = None;
     project.revision += 1;
     project.updated_at = now;

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1,9 +1,11 @@
 mod actor;
+mod app;
 mod commands;
 mod error;
 mod store;
 
 pub use actor::Actor;
+pub use app::{App, Clock, SystemClock};
 pub use commands::{
     LinkAdd, ProjectAdd, ProjectUpdate, RunFail, RunFinish, RunStart, RunUpdate, RunWait,
     TaskCreate, TaskUpdate,

--- a/crates/application/tests/projects.rs
+++ b/crates/application/tests/projects.rs
@@ -1,0 +1,428 @@
+use std::ops::Deref;
+
+use taskboard_application::{Actor, App, ProjectAdd, ProjectUpdate, SystemClock};
+use taskboard_core::ActorKind;
+use taskboard_store_sqlite::{open_db, SqliteStore};
+
+struct TestApp {
+    app: App,
+    _tmp: tempfile::TempDir,
+}
+
+impl Deref for TestApp {
+    type Target = App;
+
+    fn deref(&self) -> &Self::Target {
+        &self.app
+    }
+}
+
+fn cli_actor() -> Actor {
+    Actor {
+        kind: ActorKind::Cli,
+        label: "local-cli".into(),
+    }
+}
+
+async fn test_app() -> TestApp {
+    let tmp = tempfile::tempdir().unwrap();
+    let pool = open_db(tmp.path()).await.unwrap();
+    let store = SqliteStore::new(pool);
+    TestApp {
+        app: App::new(store, SystemClock),
+        _tmp: tmp,
+    }
+}
+
+#[tokio::test]
+async fn add_project_assigns_slug_and_revision_one() {
+    let app = test_app().await;
+    let p = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "Renai Sim".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(p.slug, "renai-sim");
+    assert_eq!(p.revision, 1);
+}
+
+#[tokio::test]
+async fn duplicate_explicit_slug_fails() {
+    let app = test_app().await;
+    app.project_add(
+        &cli_actor(),
+        ProjectAdd {
+            name: "A".into(),
+            repo_path: None,
+            slug: Some("renai-sim".into()),
+        },
+    )
+    .await
+    .unwrap();
+    let err = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "B".into(),
+                repo_path: None,
+                slug: Some("renai-sim".into()),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "duplicate_slug");
+}
+
+#[tokio::test]
+async fn second_same_name_gets_suffix() {
+    let app = test_app().await;
+    app.project_add(
+        &cli_actor(),
+        ProjectAdd {
+            name: "Renai Sim".into(),
+            repo_path: None,
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+    let p2 = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "Renai Sim".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(p2.slug, "renai-sim-2");
+}
+
+#[tokio::test]
+async fn default_list_hides_archived_and_deleted() {
+    let app = test_app().await;
+    let a = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let b = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "B".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    app.project_archive(&cli_actor(), &b.slug, true, None)
+        .await
+        .unwrap();
+    app.project_delete(&cli_actor(), &a.slug, None)
+        .await
+        .unwrap();
+    let live = app.project_list(false).await.unwrap();
+    assert!(live.is_empty());
+    let archived = app.project_list(true).await.unwrap();
+    assert_eq!(archived.len(), 1);
+    assert_eq!(archived[0].slug, b.slug);
+}
+
+#[tokio::test]
+async fn blank_name_is_validation_error() {
+    let app = test_app().await;
+    let err = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "   ".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+}
+
+#[tokio::test]
+async fn second_project_sort_order_follows_live_max() {
+    let app = test_app().await;
+    let a = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let b = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "B".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(a.sort_order, 0);
+    assert_eq!(b.sort_order, 1);
+}
+
+#[tokio::test]
+async fn project_show_returns_live_and_hides_deleted() {
+    let app = test_app().await;
+    let p = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "Renai Sim".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let shown = app.project_show(&p.slug).await.unwrap();
+    assert_eq!(shown.id, p.id);
+    app.project_delete(&cli_actor(), &p.slug, None)
+        .await
+        .unwrap();
+    let err = app.project_show(&p.slug).await.unwrap_err();
+    assert_eq!(err.code(), "not_found");
+}
+
+#[tokio::test]
+async fn project_update_renames_without_changing_slug() {
+    let app = test_app().await;
+    let p = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "Renai Sim".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let updated = app
+        .project_update(
+            &cli_actor(),
+            ProjectUpdate {
+                slug: p.slug.clone(),
+                name: Some("Renai Simulation".into()),
+                repo_path: None,
+                new_slug: None,
+                revision: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.name, "Renai Simulation");
+    assert_eq!(updated.slug, "renai-sim");
+    assert_eq!(updated.revision, 2);
+}
+
+#[tokio::test]
+async fn revision_mismatch_returns_conflict_with_current_entity() {
+    let app = test_app().await;
+    let p = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let err = app
+        .project_update(
+            &cli_actor(),
+            ProjectUpdate {
+                slug: p.slug.clone(),
+                name: Some("B".into()),
+                repo_path: None,
+                new_slug: None,
+                revision: Some(99),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "revision_conflict");
+    match err {
+        taskboard_application::AppError::RevisionConflict { current } => {
+            assert_eq!(current["slug"], "a");
+            assert_eq!(current["revision"], 1);
+        }
+        other => panic!("expected revision_conflict, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn restore_fails_when_live_project_owns_slug() {
+    let app = test_app().await;
+    let a = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: Some("renai-sim".into()),
+            },
+        )
+        .await
+        .unwrap();
+    app.project_delete(&cli_actor(), &a.slug, None)
+        .await
+        .unwrap();
+    app.project_add(
+        &cli_actor(),
+        ProjectAdd {
+            name: "B".into(),
+            repo_path: None,
+            slug: Some("renai-sim".into()),
+        },
+    )
+    .await
+    .unwrap();
+    let err = app
+        .project_restore(&cli_actor(), "renai-sim")
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "duplicate_slug");
+}
+
+#[tokio::test]
+async fn restore_brings_deleted_project_back() {
+    let app = test_app().await;
+    let p = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    app.project_delete(&cli_actor(), &p.slug, None)
+        .await
+        .unwrap();
+    let restored = app.project_restore(&cli_actor(), &p.slug).await.unwrap();
+    assert!(restored.deleted_at.is_none());
+    assert_eq!(restored.slug, p.slug);
+    assert_eq!(app.project_list(false).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn project_note_set_replaces_markdown() {
+    let app = test_app().await;
+    let p = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let updated = app
+        .project_note_set(&cli_actor(), &p.slug, "# hello".into(), None)
+        .await
+        .unwrap();
+    assert_eq!(updated.note_markdown, "# hello");
+    assert_eq!(updated.revision, 2);
+    let shown = app.project_show(&p.slug).await.unwrap();
+    assert_eq!(shown.note_markdown, "# hello");
+}
+
+#[tokio::test]
+async fn project_reorder_rewrites_sort_order() {
+    let app = test_app().await;
+    let a = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let b = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "B".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let reordered = app
+        .project_reorder(&cli_actor(), &[b.slug.clone(), a.slug.clone()])
+        .await
+        .unwrap();
+    assert_eq!(reordered[0].slug, b.slug);
+    assert_eq!(reordered[0].sort_order, 0);
+    assert_eq!(reordered[1].slug, a.slug);
+    assert_eq!(reordered[1].sort_order, 1);
+    let listed = app.project_list(false).await.unwrap();
+    assert_eq!(listed[0].slug, b.slug);
+    assert_eq!(listed[1].slug, a.slug);
+}
+
+#[tokio::test]
+async fn unarchive_returns_project_to_default_list() {
+    let app = test_app().await;
+    let p = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    app.project_archive(&cli_actor(), &p.slug, true, None)
+        .await
+        .unwrap();
+    assert!(app.project_list(false).await.unwrap().is_empty());
+    app.project_archive(&cli_actor(), &p.slug, false, None)
+        .await
+        .unwrap();
+    let live = app.project_list(false).await.unwrap();
+    assert_eq!(live.len(), 1);
+    assert!(!live[0].archived);
+}

--- a/crates/application/tests/projects.rs
+++ b/crates/application/tests/projects.rs
@@ -1,12 +1,22 @@
 use std::ops::Deref;
 
-use taskboard_application::{Actor, App, ProjectAdd, ProjectUpdate, SystemClock};
+use std::collections::HashSet;
+
+use taskboard_application::{Actor, App, ProjectAdd, ProjectUpdate, Store, SystemClock};
 use taskboard_core::ActorKind;
 use taskboard_store_sqlite::{open_db, SqliteStore};
 
 struct TestApp {
     app: App,
     _tmp: tempfile::TempDir,
+}
+
+impl TestApp {
+    async fn activity_head(&self) -> i64 {
+        let pool = open_db(self._tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool);
+        store.activity_head().await.unwrap()
+    }
 }
 
 impl Deref for TestApp {
@@ -314,6 +324,62 @@ async fn restore_fails_when_live_project_owns_slug() {
         .await
         .unwrap_err();
     assert_eq!(err.code(), "duplicate_slug");
+}
+
+#[tokio::test]
+async fn project_add_advances_activity_head() {
+    let app = test_app().await;
+    assert_eq!(app.activity_head().await, 0);
+    app.project_add(
+        &cli_actor(),
+        ProjectAdd {
+            name: "A".into(),
+            repo_path: None,
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(app.activity_head().await, 1);
+}
+
+#[tokio::test]
+async fn restore_assigns_unique_sort_order_after_live_max() {
+    let app = test_app().await;
+    let a = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(a.sort_order, 0);
+    app.project_delete(&cli_actor(), &a.slug, None)
+        .await
+        .unwrap();
+    let b = app
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "B".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(b.sort_order, 0);
+    let restored = app.project_restore(&cli_actor(), &a.slug).await.unwrap();
+    let live = app.project_list(false).await.unwrap();
+    let sort_orders: HashSet<i64> = live.iter().map(|p| p.sort_order).collect();
+    assert_eq!(sort_orders.len(), live.len());
+    let max_live = live.iter().map(|p| p.sort_order).max().unwrap();
+    assert_eq!(restored.sort_order, max_live);
+    assert_eq!(restored.sort_order, 1);
 }
 
 #[tokio::test]

--- a/crates/store-sqlite/Cargo.toml
+++ b/crates/store-sqlite/Cargo.toml
@@ -5,13 +5,16 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 taskboard-application = { path = "../application" }
 taskboard-core = { path = "../core" }
 chrono.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 toml = "=0.8.23"
+uuid.workspace = true
 
 [dev-dependencies]
 tempfile = "=3.19.1"

--- a/crates/store-sqlite/src/db.rs
+++ b/crates/store-sqlite/src/db.rs
@@ -131,7 +131,7 @@ fn map_io(err: std::io::Error) -> AppError {
     AppError::Io(err.to_string())
 }
 
-fn map_sqlx(err: sqlx::Error) -> AppError {
+pub(crate) fn map_sqlx(err: sqlx::Error) -> AppError {
     if let sqlx::Error::Database(db_err) = &err {
         let code = db_err.code();
         if matches!(code.as_deref(), Some("5" | "6")) {

--- a/crates/store-sqlite/src/lib.rs
+++ b/crates/store-sqlite/src/lib.rs
@@ -2,8 +2,10 @@ mod config;
 mod db;
 mod migrations;
 mod paths;
+mod store;
 
 pub use config::{load_config, Config};
 pub use db::open_db;
 pub use migrations::INIT_SQL;
 pub use paths::{default_data_dir, resolve_data_dir};
+pub use store::SqliteStore;

--- a/crates/store-sqlite/src/store.rs
+++ b/crates/store-sqlite/src/store.rs
@@ -1,0 +1,513 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use chrono::{DateTime, SecondsFormat, Utc};
+use sqlx::sqlite::SqliteRow;
+use sqlx::{Row, SqlitePool};
+use taskboard_application::{AppError, NewActivity, Store};
+use taskboard_core::{Activity, ActorKind, Column, EntityType, Link, Project, Run, Task};
+use uuid::Uuid;
+
+use crate::db::map_sqlx;
+
+const PROJECT_COLUMNS: &str = "id, slug, name, repo_path, archived, note_markdown, sort_order, revision, created_at, updated_at, deleted_at";
+const ACTIVITY_COLUMNS: &str = "id, sequence, actor_kind, actor_label, operation, entity_type, entity_id, previous_revision, before_json, after_json, created_at";
+
+macro_rules! run {
+    ($self:expr, $query:expr, $method:ident) => {
+        if let Some(conn) = $self.conn.as_mut() {
+            $query.$method(&mut **conn).await
+        } else {
+            $query.$method(&$self.pool).await
+        }
+    };
+}
+
+pub struct SqliteStore {
+    pool: SqlitePool,
+    conn: Option<sqlx::pool::PoolConnection<sqlx::Sqlite>>,
+}
+
+impl SqliteStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool, conn: None }
+    }
+}
+
+fn not_impl(what: &str) -> AppError {
+    AppError::Io(format!("{what} is not implemented"))
+}
+
+fn fmt_dt(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn parse_dt(raw: &str) -> Result<DateTime<Utc>, AppError> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|err| AppError::Io(err.to_string()))
+}
+
+fn uuid_from_blob(bytes: &[u8]) -> Result<Uuid, AppError> {
+    Uuid::from_slice(bytes).map_err(|err| AppError::Io(err.to_string()))
+}
+
+fn uuid_bytes(id: Uuid) -> Vec<u8> {
+    id.as_bytes().to_vec()
+}
+
+fn map_constraint(err: sqlx::Error, slug: &str) -> AppError {
+    if let sqlx::Error::Database(db_err) = &err {
+        if db_err.message().contains("UNIQUE") {
+            return AppError::DuplicateSlug {
+                slug: slug.to_string(),
+            };
+        }
+    }
+    map_sqlx(err)
+}
+
+fn enum_str<T: serde::Serialize>(value: T) -> Result<String, AppError> {
+    match serde_json::to_value(value).map_err(|err| AppError::Io(err.to_string()))? {
+        serde_json::Value::String(s) => Ok(s),
+        other => Err(AppError::Io(format!("expected enum string, got {other}"))),
+    }
+}
+
+fn parse_enum<T: serde::de::DeserializeOwned>(raw: &str) -> Result<T, AppError> {
+    serde_json::from_value(serde_json::Value::String(raw.to_string()))
+        .map_err(|err| AppError::Io(err.to_string()))
+}
+
+fn project_from_row(row: &SqliteRow) -> Result<Project, AppError> {
+    let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+    let created_at: String = row.try_get("created_at").map_err(map_sqlx)?;
+    let updated_at: String = row.try_get("updated_at").map_err(map_sqlx)?;
+    let deleted_at: Option<String> = row.try_get("deleted_at").map_err(map_sqlx)?;
+    let archived: i64 = row.try_get("archived").map_err(map_sqlx)?;
+    Ok(Project {
+        id: uuid_from_blob(&id)?,
+        slug: row.try_get("slug").map_err(map_sqlx)?,
+        name: row.try_get("name").map_err(map_sqlx)?,
+        repo_path: row.try_get("repo_path").map_err(map_sqlx)?,
+        archived: archived != 0,
+        note_markdown: row.try_get("note_markdown").map_err(map_sqlx)?,
+        sort_order: row.try_get("sort_order").map_err(map_sqlx)?,
+        revision: row.try_get("revision").map_err(map_sqlx)?,
+        created_at: parse_dt(&created_at)?,
+        updated_at: parse_dt(&updated_at)?,
+        deleted_at: deleted_at.as_deref().map(parse_dt).transpose()?,
+    })
+}
+
+fn activity_from_row(row: &SqliteRow) -> Result<Activity, AppError> {
+    let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+    let entity_id: Vec<u8> = row.try_get("entity_id").map_err(map_sqlx)?;
+    let actor_kind: String = row.try_get("actor_kind").map_err(map_sqlx)?;
+    let entity_type: String = row.try_get("entity_type").map_err(map_sqlx)?;
+    let before_json: Option<String> = row.try_get("before_json").map_err(map_sqlx)?;
+    let after_json: Option<String> = row.try_get("after_json").map_err(map_sqlx)?;
+    let created_at: String = row.try_get("created_at").map_err(map_sqlx)?;
+    Ok(Activity {
+        id: uuid_from_blob(&id)?,
+        sequence: row.try_get("sequence").map_err(map_sqlx)?,
+        actor_kind: parse_enum::<ActorKind>(&actor_kind)?,
+        actor_label: row.try_get("actor_label").map_err(map_sqlx)?,
+        operation: row.try_get("operation").map_err(map_sqlx)?,
+        entity_type: parse_enum::<EntityType>(&entity_type)?,
+        entity_id: uuid_from_blob(&entity_id)?,
+        previous_revision: row.try_get("previous_revision").map_err(map_sqlx)?,
+        before_json: before_json
+            .map(|s| serde_json::from_str(&s))
+            .transpose()
+            .map_err(|err| AppError::Io(err.to_string()))?,
+        after_json: after_json
+            .map(|s| serde_json::from_str(&s))
+            .transpose()
+            .map_err(|err| AppError::Io(err.to_string()))?,
+        created_at: parse_dt(&created_at)?,
+    })
+}
+
+#[async_trait]
+impl Store for SqliteStore {
+    async fn next_display_n(&mut self, counter: &str) -> Result<i64, AppError> {
+        let query = sqlx::query_scalar(
+            "UPDATE counters SET value = value + 1 WHERE name = ? RETURNING value",
+        )
+        .bind(counter);
+        let value: Option<i64> = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        value.ok_or_else(|| AppError::Io(format!("unknown counter `{counter}`")))
+    }
+
+    async fn next_activity_sequence(&mut self) -> Result<i64, AppError> {
+        self.next_display_n("activity").await
+    }
+
+    async fn insert_activity(&mut self, row: NewActivity) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "INSERT INTO activities (id, sequence, actor_kind, actor_label, operation, entity_type, entity_id, previous_revision, before_json, after_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(uuid_bytes(row.id))
+        .bind(row.sequence)
+        .bind(enum_str(row.actor_kind)?)
+        .bind(&row.actor_label)
+        .bind(&row.operation)
+        .bind(enum_str(row.entity_type)?)
+        .bind(uuid_bytes(row.entity_id))
+        .bind(row.previous_revision)
+        .bind(row.before_json.as_ref().map(|v| v.to_string()))
+        .bind(row.after_json.as_ref().map(|v| v.to_string()))
+        .bind(fmt_dt(row.created_at));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
+    }
+
+    async fn get_project(&mut self, id: Uuid) -> Result<Option<Project>, AppError> {
+        let sql = format!("SELECT {PROJECT_COLUMNS} FROM projects WHERE id = ?");
+        let query = sqlx::query(&sql).bind(uuid_bytes(id));
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(project_from_row).transpose()
+    }
+
+    async fn get_project_by_slug(
+        &mut self,
+        slug: &str,
+        include_deleted: bool,
+    ) -> Result<Option<Project>, AppError> {
+        let sql = if include_deleted {
+            format!(
+                "SELECT {PROJECT_COLUMNS} FROM projects WHERE slug = ? ORDER BY CASE WHEN deleted_at IS NULL THEN 0 ELSE 1 END, deleted_at DESC LIMIT 1"
+            )
+        } else {
+            format!("SELECT {PROJECT_COLUMNS} FROM projects WHERE slug = ? AND deleted_at IS NULL")
+        };
+        let query = sqlx::query(&sql).bind(slug);
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(project_from_row).transpose()
+    }
+
+    async fn list_projects(&mut self, include_archived: bool) -> Result<Vec<Project>, AppError> {
+        let sql = format!(
+            "SELECT {PROJECT_COLUMNS} FROM projects WHERE deleted_at IS NULL AND (archived = 0 OR ?) ORDER BY sort_order ASC"
+        );
+        let query = sqlx::query(&sql).bind(if include_archived { 1i64 } else { 0 });
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(project_from_row).collect()
+    }
+
+    async fn list_deleted_projects(&mut self) -> Result<Vec<Project>, AppError> {
+        let sql = format!(
+            "SELECT {PROJECT_COLUMNS} FROM projects WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC"
+        );
+        let query = sqlx::query(&sql);
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(project_from_row).collect()
+    }
+
+    async fn insert_project(&mut self, project: &Project) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "INSERT INTO projects (id, slug, name, repo_path, archived, note_markdown, sort_order, revision, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(uuid_bytes(project.id))
+        .bind(&project.slug)
+        .bind(&project.name)
+        .bind(&project.repo_path)
+        .bind(if project.archived { 1i64 } else { 0 })
+        .bind(&project.note_markdown)
+        .bind(project.sort_order)
+        .bind(project.revision)
+        .bind(fmt_dt(project.created_at))
+        .bind(fmt_dt(project.updated_at))
+        .bind(project.deleted_at.map(fmt_dt));
+        run!(self, query, execute).map_err(|err| map_constraint(err, &project.slug))?;
+        Ok(())
+    }
+
+    async fn update_project(&mut self, project: &Project) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "UPDATE projects SET slug = ?, name = ?, repo_path = ?, archived = ?, note_markdown = ?, sort_order = ?, revision = ?, created_at = ?, updated_at = ?, deleted_at = ? WHERE id = ?",
+        )
+        .bind(&project.slug)
+        .bind(&project.name)
+        .bind(&project.repo_path)
+        .bind(if project.archived { 1i64 } else { 0 })
+        .bind(&project.note_markdown)
+        .bind(project.sort_order)
+        .bind(project.revision)
+        .bind(fmt_dt(project.created_at))
+        .bind(fmt_dt(project.updated_at))
+        .bind(project.deleted_at.map(fmt_dt))
+        .bind(uuid_bytes(project.id));
+        run!(self, query, execute).map_err(|err| map_constraint(err, &project.slug))?;
+        Ok(())
+    }
+
+    async fn soft_delete_project(
+        &mut self,
+        id: Uuid,
+        deleted_at: DateTime<Utc>,
+    ) -> Result<(), AppError> {
+        let query = sqlx::query("UPDATE projects SET deleted_at = ? WHERE id = ?")
+            .bind(fmt_dt(deleted_at))
+            .bind(uuid_bytes(id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
+    }
+
+    async fn restore_project(&mut self, id: Uuid) -> Result<(), AppError> {
+        let query =
+            sqlx::query("UPDATE projects SET deleted_at = NULL WHERE id = ?").bind(uuid_bytes(id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
+    }
+
+    async fn rewrite_project_sort_orders(&mut self, ordered_ids: &[Uuid]) -> Result<(), AppError> {
+        for (index, id) in ordered_ids.iter().enumerate() {
+            let query = sqlx::query("UPDATE projects SET sort_order = ? WHERE id = ?")
+                .bind(index as i64)
+                .bind(uuid_bytes(*id));
+            run!(self, query, execute).map_err(map_sqlx)?;
+        }
+        Ok(())
+    }
+
+    async fn get_task(&mut self, _id: Uuid) -> Result<Option<Task>, AppError> {
+        Err(not_impl("get_task"))
+    }
+
+    async fn get_task_by_display_id(
+        &mut self,
+        _display_id: &str,
+        _include_deleted: bool,
+    ) -> Result<Option<Task>, AppError> {
+        Err(not_impl("get_task_by_display_id"))
+    }
+
+    async fn list_tasks(&mut self, _project_id: Uuid) -> Result<Vec<Task>, AppError> {
+        Err(not_impl("list_tasks"))
+    }
+
+    async fn list_deleted_tasks(&mut self) -> Result<Vec<Task>, AppError> {
+        Err(not_impl("list_deleted_tasks"))
+    }
+
+    async fn insert_task(&mut self, _task: &Task) -> Result<(), AppError> {
+        Err(not_impl("insert_task"))
+    }
+
+    async fn update_task(&mut self, _task: &Task) -> Result<(), AppError> {
+        Err(not_impl("update_task"))
+    }
+
+    async fn soft_delete_task(
+        &mut self,
+        _id: Uuid,
+        _deleted_at: DateTime<Utc>,
+    ) -> Result<(), AppError> {
+        Err(not_impl("soft_delete_task"))
+    }
+
+    async fn restore_task(&mut self, _id: Uuid) -> Result<(), AppError> {
+        Err(not_impl("restore_task"))
+    }
+
+    async fn rewrite_task_positions(
+        &mut self,
+        _project_id: Uuid,
+        _column: Column,
+        _ordered_ids: &[Uuid],
+    ) -> Result<(), AppError> {
+        Err(not_impl("rewrite_task_positions"))
+    }
+
+    async fn get_link(&mut self, _id: Uuid) -> Result<Option<Link>, AppError> {
+        Err(not_impl("get_link"))
+    }
+
+    async fn list_links(&mut self, _task_id: Uuid) -> Result<Vec<Link>, AppError> {
+        Err(not_impl("list_links"))
+    }
+
+    async fn insert_link(&mut self, _link: &Link) -> Result<(), AppError> {
+        Err(not_impl("insert_link"))
+    }
+
+    async fn update_link(&mut self, _link: &Link) -> Result<(), AppError> {
+        Err(not_impl("update_link"))
+    }
+
+    async fn delete_link(&mut self, _id: Uuid) -> Result<(), AppError> {
+        Err(not_impl("delete_link"))
+    }
+
+    async fn get_run(&mut self, _id: Uuid) -> Result<Option<Run>, AppError> {
+        Err(not_impl("get_run"))
+    }
+
+    async fn get_run_by_display_id(&mut self, _display_id: &str) -> Result<Option<Run>, AppError> {
+        Err(not_impl("get_run_by_display_id"))
+    }
+
+    async fn list_runs(&mut self, _task_id: Uuid) -> Result<Vec<Run>, AppError> {
+        Err(not_impl("list_runs"))
+    }
+
+    async fn insert_run(&mut self, _run: &Run) -> Result<(), AppError> {
+        Err(not_impl("insert_run"))
+    }
+
+    async fn update_run(&mut self, _run: &Run) -> Result<(), AppError> {
+        Err(not_impl("update_run"))
+    }
+
+    async fn delete_run(&mut self, _id: Uuid) -> Result<(), AppError> {
+        Err(not_impl("delete_run"))
+    }
+
+    async fn activity_head(&mut self) -> Result<i64, AppError> {
+        let query = sqlx::query_scalar("SELECT COALESCE(MAX(sequence), 0) FROM activities");
+        run!(self, query, fetch_one).map_err(map_sqlx)
+    }
+
+    async fn latest_activity_for(&mut self, entity_id: Uuid) -> Result<Option<Activity>, AppError> {
+        let sql = format!(
+            "SELECT {ACTIVITY_COLUMNS} FROM activities WHERE entity_id = ? ORDER BY sequence DESC LIMIT 1"
+        );
+        let query = sqlx::query(&sql).bind(uuid_bytes(entity_id));
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(activity_from_row).transpose()
+    }
+
+    async fn latest_undoable(&mut self) -> Result<Option<Activity>, AppError> {
+        let sql = format!(
+            "SELECT {ACTIVITY_COLUMNS} FROM activities WHERE operation != 'undo' ORDER BY sequence DESC LIMIT 1"
+        );
+        let query = sqlx::query(&sql);
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(activity_from_row).transpose()
+    }
+
+    async fn list_activities_after(&mut self, sequence: i64) -> Result<Vec<Activity>, AppError> {
+        let sql = format!(
+            "SELECT {ACTIVITY_COLUMNS} FROM activities WHERE sequence > ? ORDER BY sequence ASC"
+        );
+        let query = sqlx::query(&sql).bind(sequence);
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(activity_from_row).collect()
+    }
+
+    async fn list_recent_activities(
+        &mut self,
+        entity_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<Activity>, AppError> {
+        let sql = format!(
+            "SELECT {ACTIVITY_COLUMNS} FROM activities WHERE entity_id = ? ORDER BY sequence DESC LIMIT ?"
+        );
+        let query = sqlx::query(&sql).bind(uuid_bytes(entity_id)).bind(limit);
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(activity_from_row).collect()
+    }
+
+    async fn purge_expired(
+        &mut self,
+        _now: DateTime<Utc>,
+        _retention_days: i64,
+    ) -> Result<u64, AppError> {
+        Err(not_impl("purge_expired"))
+    }
+
+    async fn backup_to(&mut self, _dest: &Path) -> Result<(), AppError> {
+        Err(not_impl("backup_to"))
+    }
+
+    async fn replace_from(&mut self, _src: &Path) -> Result<(), AppError> {
+        Err(not_impl("replace_from"))
+    }
+
+    async fn begin(&mut self) -> Result<(), AppError> {
+        if self.conn.is_some() {
+            return Err(AppError::Io("transaction already active".into()));
+        }
+        let mut conn = self.pool.acquire().await.map_err(map_sqlx)?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx)?;
+        self.conn = Some(conn);
+        Ok(())
+    }
+
+    async fn commit(&mut self) -> Result<(), AppError> {
+        let mut conn = self
+            .conn
+            .take()
+            .ok_or_else(|| AppError::Io("no active transaction".into()))?;
+        let result = sqlx::query("COMMIT")
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx);
+        if result.is_err() {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        }
+        result?;
+        Ok(())
+    }
+
+    async fn rollback(&mut self) -> Result<(), AppError> {
+        let Some(mut conn) = self.conn.take() else {
+            return Ok(());
+        };
+        sqlx::query("ROLLBACK")
+            .execute(&mut *conn)
+            .await
+            .map_err(map_sqlx)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[tokio::test]
+    async fn stores_uuid_as_blob16_and_timestamps_with_z() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = crate::open_db(tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool.clone());
+        let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+        let project = Project {
+            id: Uuid::now_v7(),
+            slug: "renai-sim".into(),
+            name: "Renai Sim".into(),
+            repo_path: None,
+            archived: false,
+            note_markdown: String::new(),
+            sort_order: 0,
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.insert_project(&project).await.unwrap();
+
+        let id_type: String = sqlx::query_scalar("SELECT typeof(id) FROM projects")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let id_len: i64 = sqlx::query_scalar("SELECT length(id) FROM projects")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let created_at: String = sqlx::query_scalar("SELECT created_at FROM projects")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(id_type, "blob");
+        assert_eq!(id_len, 16);
+        assert_eq!(created_at, "2026-09-05T12:00:00.000Z");
+        pool.close().await;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #9

Plan 1 Task 7: project use cases (`add`/`list`/`update`/`reorder`/`archive`/`delete`/`restore`/`note`/`show`) persisted in SQLite with activity rows. Restore assigns a unique live `sort_order`.

Verify: `cargo test -p taskboard-application --test projects` (16 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

