### PR TITLE
feat: add task create, move, and reorder

### DIFF
--- a/crates/application/src/app.rs
+++ b/crates/application/src/app.rs
@@ -3,12 +3,14 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use taskboard_core::{
-    next_unique_slug, slugify, trim_project_name, EntityType, FieldError, Project, SlugError,
-    ValidationError,
+    card_display_status, display_id, next_unique_slug, place_before, place_urgent,
+    rewrite_positions, slugify, sort_column, trim_project_name, trim_title, Column, DisplayKind,
+    EntityType, FieldError, OrderError, OrderKey, Project, RunStatusView, SlugError, Task,
+    TaskDetail, TaskSummary, ValidationError,
 };
 
 use crate::actor::Actor;
-use crate::commands::{ProjectAdd, ProjectUpdate};
+use crate::commands::{ProjectAdd, ProjectUpdate, TaskCreate, TaskUpdate};
 use crate::error::AppError;
 use crate::store::{NewActivity, Store};
 
@@ -135,6 +137,97 @@ impl App {
         let result = project_note_set_inner(store, actor, slug, markdown, revision, now).await;
         commit_or_rollback(store, result).await
     }
+
+    pub async fn task_create(
+        &self,
+        actor: &Actor,
+        cmd: TaskCreate,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_create_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_list(&self, project_slug: &str) -> Result<Vec<TaskSummary>, AppError> {
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        let project = require_live_project(store, project_slug).await?;
+        let tasks = store.list_tasks(project.id).await?;
+        let mut summaries = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            summaries.push(to_task_summary(store, task).await?);
+        }
+        Ok(summaries)
+    }
+
+    pub async fn task_show(&self, display_id: &str) -> Result<TaskDetail, AppError> {
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        let task = require_live_task(store, display_id).await?;
+        load_task_detail(store, task).await
+    }
+
+    pub async fn task_update(
+        &self,
+        actor: &Actor,
+        cmd: TaskUpdate,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_update_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_move(
+        &self,
+        actor: &Actor,
+        display_id: &str,
+        column: Column,
+        revision: Option<i64>,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_move_inner(store, actor, display_id, column, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_reorder(
+        &self,
+        actor: &Actor,
+        display_id: &str,
+        before_display_id: Option<&str>,
+        revision: Option<i64>,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result =
+            task_reorder_inner(store, actor, display_id, before_display_id, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_urgent(
+        &self,
+        actor: &Actor,
+        display_id: &str,
+        urgent: bool,
+        revision: Option<i64>,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_urgent_inner(store, actor, display_id, urgent, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
 }
 
 async fn commit_or_rollback<T>(
@@ -199,6 +292,7 @@ async fn project_add_inner(
         actor,
         now,
         ActivityWrite {
+            entity_type: EntityType::Project,
             operation: "project.create",
             entity_id: project.id,
             previous_revision: None,
@@ -217,7 +311,7 @@ async fn project_update_inner(
     now: DateTime<Utc>,
 ) -> Result<Project, AppError> {
     let mut project = require_live_project(store, &cmd.slug).await?;
-    check_revision(&project, cmd.revision)?;
+    check_revision(&project, project.revision, cmd.revision)?;
     let before = project.clone();
     if let Some(name) = cmd.name {
         project.name = trim_project_name(&name).map_err(map_validation)?;
@@ -246,6 +340,7 @@ async fn project_update_inner(
         actor,
         now,
         ActivityWrite {
+            entity_type: EntityType::Project,
             operation: "project.update",
             entity_id: project.id,
             previous_revision: Some(before.revision),
@@ -306,6 +401,7 @@ async fn project_reorder_inner(
         actor,
         now,
         ActivityWrite {
+            entity_type: EntityType::Project,
             operation: "project.reorder",
             entity_id: ordered[0].id,
             previous_revision: None,
@@ -326,7 +422,7 @@ async fn project_archive_inner(
     now: DateTime<Utc>,
 ) -> Result<Project, AppError> {
     let mut project = require_live_project(store, slug).await?;
-    check_revision(&project, revision)?;
+    check_revision(&project, project.revision, revision)?;
     let before = project.clone();
     project.archived = archived;
     project.revision += 1;
@@ -342,6 +438,7 @@ async fn project_archive_inner(
         actor,
         now,
         ActivityWrite {
+            entity_type: EntityType::Project,
             operation,
             entity_id: project.id,
             previous_revision: Some(before.revision),
@@ -361,7 +458,7 @@ async fn project_delete_inner(
     now: DateTime<Utc>,
 ) -> Result<Project, AppError> {
     let mut project = require_live_project(store, slug).await?;
-    check_revision(&project, revision)?;
+    check_revision(&project, project.revision, revision)?;
     let before = project.clone();
     project.deleted_at = Some(now);
     project.revision += 1;
@@ -372,6 +469,7 @@ async fn project_delete_inner(
         actor,
         now,
         ActivityWrite {
+            entity_type: EntityType::Project,
             operation: "project.delete",
             entity_id: project.id,
             previous_revision: Some(before.revision),
@@ -428,6 +526,7 @@ async fn project_restore_inner(
         actor,
         now,
         ActivityWrite {
+            entity_type: EntityType::Project,
             operation: "project.restore",
             entity_id: project.id,
             previous_revision: Some(before.revision),
@@ -448,7 +547,7 @@ async fn project_note_set_inner(
     now: DateTime<Utc>,
 ) -> Result<Project, AppError> {
     let mut project = require_live_project(store, slug).await?;
-    check_revision(&project, revision)?;
+    check_revision(&project, project.revision, revision)?;
     let before = project.clone();
     project.note_markdown = markdown;
     project.revision += 1;
@@ -459,6 +558,7 @@ async fn project_note_set_inner(
         actor,
         now,
         ActivityWrite {
+            entity_type: EntityType::Project,
             operation: "project.note.set",
             entity_id: project.id,
             previous_revision: Some(before.revision),
@@ -468,6 +568,402 @@ async fn project_note_set_inner(
     )
     .await?;
     Ok(project)
+}
+
+async fn task_create_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: TaskCreate,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let title = trim_title(&cmd.title).map_err(map_validation)?;
+    let project = require_live_project(store, &cmd.project_slug).await?;
+    let column = cmd.column.unwrap_or(Column::Todo);
+    let n = store.next_display_n("task").await?;
+    let display_id = display_id(DisplayKind::Task, n);
+    let existing = store.list_tasks(project.id).await?;
+    let mut column_tasks: Vec<Task> = existing
+        .into_iter()
+        .filter(|task| task.column == column)
+        .collect();
+    let mut keys = task_keys(&column_tasks);
+    insert_into_urgency_group(&mut keys, display_id.clone(), cmd.urgent);
+    let position = position_of(&keys, &display_id);
+    let task = Task {
+        id: Uuid::now_v7(),
+        display_id: display_id.clone(),
+        project_id: project.id,
+        title,
+        column,
+        urgent: cmd.urgent,
+        note_markdown: String::new(),
+        position: column_tasks.len() as i64,
+        revision: 1,
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+    store.insert_task(&task).await?;
+    column_tasks.push(task.clone());
+    rewrite_column(store, project.id, column, &keys, &column_tasks).await?;
+    let mut task = task;
+    task.position = position;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.create",
+            entity_id: task.id,
+            previous_revision: None,
+            before_json: None,
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn task_update_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: TaskUpdate,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = require_live_task(store, &cmd.display_id).await?;
+    check_revision(&task, task.revision, cmd.revision)?;
+    let before = task.clone();
+    if let Some(title) = cmd.title {
+        task.title = trim_title(&title).map_err(map_validation)?;
+    }
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.update",
+            entity_id: task.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn task_move_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    dest: Column,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = require_live_task(store, display_id).await?;
+    check_revision(&task, task.revision, revision)?;
+    let before = task.clone();
+    let source = task.column;
+    let all = store.list_tasks(task.project_id).await?;
+    if source == dest {
+        let column_tasks: Vec<Task> = all
+            .into_iter()
+            .filter(|item| item.column == source)
+            .collect();
+        let mut keys = task_keys(&column_tasks);
+        keys.retain(|key| key.display_id != task.display_id);
+        insert_into_urgency_group(&mut keys, task.display_id.clone(), task.urgent);
+        rewrite_column(store, task.project_id, source, &keys, &column_tasks).await?;
+        task.position = position_of(&keys, &task.display_id);
+    } else {
+        let source_tasks: Vec<Task> = all
+            .iter()
+            .filter(|item| item.column == source && item.id != task.id)
+            .cloned()
+            .collect();
+        let mut dest_tasks: Vec<Task> = all
+            .iter()
+            .filter(|item| item.column == dest)
+            .cloned()
+            .collect();
+        let mut source_keys = task_keys(&source_tasks);
+        rewrite_positions(&mut source_keys);
+        let mut dest_keys = task_keys(&dest_tasks);
+        insert_into_urgency_group(&mut dest_keys, task.display_id.clone(), task.urgent);
+        task.column = dest;
+        task.position = dest_tasks.len() as i64;
+        task.revision += 1;
+        task.updated_at = now;
+        store.update_task(&task).await?;
+        dest_tasks.push(task.clone());
+        rewrite_column(store, task.project_id, source, &source_keys, &source_tasks).await?;
+        rewrite_column(store, task.project_id, dest, &dest_keys, &dest_tasks).await?;
+        task.position = position_of(&dest_keys, &task.display_id);
+    }
+    if source == dest {
+        task.revision += 1;
+        task.updated_at = now;
+        store.update_task(&task).await?;
+    }
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.move",
+            entity_id: task.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn task_reorder_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    before_display_id: Option<&str>,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = require_live_task(store, display_id).await?;
+    check_revision(&task, task.revision, revision)?;
+    let before = task.clone();
+    if let Some(before_id) = before_display_id {
+        let other = require_live_task(store, before_id).await?;
+        if other.column != task.column {
+            return Err(AppError::DifferentColumn {
+                left: task.column.as_str().to_string(),
+                right: other.column.as_str().to_string(),
+            });
+        }
+    }
+    let column_tasks: Vec<Task> = store
+        .list_tasks(task.project_id)
+        .await?
+        .into_iter()
+        .filter(|item| item.column == task.column)
+        .collect();
+    let mut keys = task_keys(&column_tasks);
+    place_before(&mut keys, &task.display_id, before_display_id).map_err(map_order_error)?;
+    sort_column(&mut keys);
+    rewrite_positions(&mut keys);
+    rewrite_column(store, task.project_id, task.column, &keys, &column_tasks).await?;
+    task.position = position_of(&keys, &task.display_id);
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.reorder",
+            entity_id: task.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn task_urgent_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    urgent: bool,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = require_live_task(store, display_id).await?;
+    check_revision(&task, task.revision, revision)?;
+    let before = task.clone();
+    let column_tasks: Vec<Task> = store
+        .list_tasks(task.project_id)
+        .await?
+        .into_iter()
+        .filter(|item| item.column == task.column)
+        .collect();
+    let mut keys = task_keys(&column_tasks);
+    place_urgent(&mut keys, &task.display_id, urgent);
+    rewrite_column(store, task.project_id, task.column, &keys, &column_tasks).await?;
+    task.urgent = urgent;
+    task.position = position_of(&keys, &task.display_id);
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.urgent",
+            entity_id: task.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn require_live_task(store: &mut dyn Store, display_id: &str) -> Result<Task, AppError> {
+    store
+        .get_task_by_display_id(display_id, false)
+        .await?
+        .ok_or_else(|| task_not_found(display_id))
+}
+
+fn task_not_found(display_id: &str) -> AppError {
+    AppError::NotFound {
+        entity: "task".into(),
+        id: display_id.to_string(),
+    }
+}
+
+fn task_keys(tasks: &[Task]) -> Vec<OrderKey> {
+    tasks
+        .iter()
+        .map(|task| OrderKey {
+            display_id: task.display_id.clone(),
+            urgent: task.urgent,
+            position: task.position,
+        })
+        .collect()
+}
+
+fn insert_into_urgency_group(keys: &mut Vec<OrderKey>, display_id: String, urgent: bool) {
+    let insert_at = if urgent {
+        keys.iter()
+            .rposition(|key| key.urgent)
+            .map(|index| index + 1)
+            .unwrap_or(0)
+    } else {
+        keys.len()
+    };
+    keys.insert(
+        insert_at,
+        OrderKey {
+            display_id,
+            urgent,
+            position: 0,
+        },
+    );
+    rewrite_positions(keys);
+}
+
+fn position_of(keys: &[OrderKey], display_id: &str) -> i64 {
+    keys.iter()
+        .find(|key| key.display_id == display_id)
+        .map(|key| key.position)
+        .expect("display_id must exist in column keys")
+}
+
+fn ids_from_keys(keys: &[OrderKey], tasks: &[Task]) -> Vec<Uuid> {
+    let by_display: std::collections::HashMap<&str, Uuid> = tasks
+        .iter()
+        .map(|task| (task.display_id.as_str(), task.id))
+        .collect();
+    keys.iter()
+        .map(|key| by_display[key.display_id.as_str()])
+        .collect()
+}
+
+async fn rewrite_column(
+    store: &mut dyn Store,
+    project_id: Uuid,
+    column: Column,
+    keys: &[OrderKey],
+    tasks: &[Task],
+) -> Result<(), AppError> {
+    store
+        .rewrite_task_positions(project_id, column, &ids_from_keys(keys, tasks))
+        .await
+}
+
+async fn load_task_detail(store: &mut dyn Store, task: Task) -> Result<TaskDetail, AppError> {
+    let links = store.list_links(task.id).await?;
+    let runs = store.list_runs(task.id).await?;
+    let recent_activities = store.list_recent_activities(task.id, 20).await?;
+    let (display_status, run_message) = display_from_runs(&runs);
+    Ok(TaskDetail {
+        id: task.id,
+        display_id: task.display_id,
+        project_id: task.project_id,
+        title: task.title,
+        column: task.column,
+        urgent: task.urgent,
+        revision: task.revision,
+        display_status,
+        run_message,
+        note_markdown: task.note_markdown,
+        links,
+        runs,
+        recent_activities,
+    })
+}
+
+async fn to_task_summary(store: &mut dyn Store, task: Task) -> Result<TaskSummary, AppError> {
+    let runs = store.list_runs(task.id).await?;
+    let (display_status, run_message) = display_from_runs(&runs);
+    Ok(TaskSummary {
+        id: task.id,
+        display_id: task.display_id,
+        project_id: task.project_id,
+        title: task.title,
+        column: task.column,
+        urgent: task.urgent,
+        revision: task.revision,
+        display_status,
+        run_message,
+    })
+}
+
+fn display_from_runs(
+    runs: &[taskboard_core::Run],
+) -> (taskboard_core::CardDisplayStatus, Option<String>) {
+    let views: Vec<RunStatusView> = runs
+        .iter()
+        .map(|run| RunStatusView {
+            status: run.status,
+            started_at: run.started_at,
+            display_id: run.display_id.clone(),
+        })
+        .collect();
+    let display_status = card_display_status(&views);
+    let run_message = runs
+        .iter()
+        .max_by(|left, right| {
+            left.started_at
+                .cmp(&right.started_at)
+                .then_with(|| left.display_id.cmp(&right.display_id))
+        })
+        .and_then(|run| run.message.clone());
+    (display_status, run_message)
+}
+
+fn map_order_error(err: OrderError) -> AppError {
+    match err {
+        OrderError::NotInColumn { display_id } => AppError::NotFound {
+            entity: "task".into(),
+            id: display_id,
+        },
+        OrderError::DifferentColumn { left, right } => AppError::DifferentColumn { left, right },
+    }
 }
 
 async fn require_live_project(store: &mut dyn Store, slug: &str) -> Result<Project, AppError> {
@@ -484,11 +980,15 @@ fn project_not_found(slug: &str) -> AppError {
     }
 }
 
-fn check_revision(project: &Project, expected: Option<i64>) -> Result<(), AppError> {
+fn check_revision<T: serde::Serialize>(
+    entity: &T,
+    current: i64,
+    expected: Option<i64>,
+) -> Result<(), AppError> {
     if let Some(expected) = expected {
-        if expected != project.revision {
+        if expected != current {
             return Err(AppError::RevisionConflict {
-                current: serde_json::to_value(project).map_err(map_json)?,
+                current: serde_json::to_value(entity).map_err(map_json)?,
             });
         }
     }
@@ -497,6 +997,7 @@ fn check_revision(project: &Project, expected: Option<i64>) -> Result<(), AppErr
 
 struct ActivityWrite {
     operation: &'static str,
+    entity_type: EntityType,
     entity_id: Uuid,
     previous_revision: Option<i64>,
     before_json: Option<serde_json::Value>,
@@ -517,7 +1018,7 @@ async fn record_activity(
             actor_kind: actor.kind,
             actor_label: actor.label.clone(),
             operation: write.operation.to_string(),
-            entity_type: EntityType::Project,
+            entity_type: write.entity_type,
             entity_id: write.entity_id,
             previous_revision: write.previous_revision,
             before_json: write.before_json,

--- a/crates/application/tests/tasks.rs
+++ b/crates/application/tests/tasks.rs
@@ -1,0 +1,394 @@
+use std::ops::Deref;
+
+use taskboard_application::{
+    Actor, App, AppError, ProjectAdd, Store, SystemClock, TaskCreate, TaskUpdate,
+};
+use taskboard_core::{ActorKind, CardDisplayStatus, Column, Task};
+use taskboard_store_sqlite::{open_db, SqliteStore};
+
+struct TestApp {
+    app: App,
+    _tmp: tempfile::TempDir,
+}
+
+impl TestApp {
+    async fn task_row(&self, display_id: &str) -> Task {
+        let pool = open_db(self._tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool);
+        store
+            .get_task_by_display_id(display_id, false)
+            .await
+            .unwrap()
+            .unwrap()
+    }
+}
+
+impl Deref for TestApp {
+    type Target = App;
+
+    fn deref(&self) -> &Self::Target {
+        &self.app
+    }
+}
+
+fn cli_actor() -> Actor {
+    Actor {
+        kind: ActorKind::Cli,
+        label: "local-cli".into(),
+    }
+}
+
+async fn test_app() -> TestApp {
+    let tmp = tempfile::tempdir().unwrap();
+    let pool = open_db(tmp.path()).await.unwrap();
+    let store = SqliteStore::new(pool);
+    TestApp {
+        app: App::new(store, SystemClock),
+        _tmp: tmp,
+    }
+}
+
+async fn seeded() -> TestApp {
+    let app = test_app().await;
+    app.project_add(
+        &cli_actor(),
+        ProjectAdd {
+            name: "Renai Sim".into(),
+            repo_path: None,
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+    app
+}
+
+async fn create_task(app: &App, title: &str, column: Option<Column>, urgent: bool) {
+    app.task_create(
+        &cli_actor(),
+        TaskCreate {
+            project_slug: "renai-sim".into(),
+            title: title.into(),
+            column,
+            urgent,
+        },
+    )
+    .await
+    .unwrap();
+}
+
+async fn seeded_with_two_tasks() -> TestApp {
+    let app = seeded().await;
+    create_task(&app, "First", None, false).await;
+    create_task(&app, "Second", None, false).await;
+    app
+}
+
+async fn seeded_with_two_tasks_in_different_columns() -> TestApp {
+    let app = seeded_with_two_tasks().await;
+    app.task_move(&cli_actor(), "TASK-1", Column::InProgress, None)
+        .await
+        .unwrap();
+    app
+}
+
+fn todo_ids(list: &[taskboard_core::TaskSummary]) -> Vec<&str> {
+    list.iter()
+        .filter(|t| t.column == Column::Todo)
+        .map(|t| t.display_id.as_str())
+        .collect()
+}
+
+#[tokio::test]
+async fn create_task_gets_task_1_in_todo() {
+    let app = seeded().await;
+    let t = app
+        .task_create(
+            &cli_actor(),
+            TaskCreate {
+                project_slug: "renai-sim".into(),
+                title: "Fix login error".into(),
+                column: None,
+                urgent: false,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(t.display_id, "TASK-1");
+    assert_eq!(t.column, Column::Todo);
+    assert_eq!(t.display_status, CardDisplayStatus::Idle);
+    assert!(t.links.is_empty());
+    assert!(t.runs.is_empty());
+    assert_eq!(t.revision, 1);
+}
+
+#[tokio::test]
+async fn move_rewrites_positions_in_both_columns() {
+    let app = seeded_with_two_tasks().await;
+    app.task_move(&cli_actor(), "TASK-1", Column::InProgress, None)
+        .await
+        .unwrap();
+    let listed = app.task_list("renai-sim").await.unwrap();
+    assert_eq!(todo_ids(&listed), ["TASK-2"]);
+    let remaining = app.task_show("TASK-2").await.unwrap();
+    assert_eq!(remaining.column, Column::Todo);
+    assert_eq!(remaining.display_id, "TASK-2");
+    assert_eq!(app.task_row("TASK-2").await.position, 0);
+    assert_eq!(app.task_row("TASK-1").await.position, 0);
+    assert_eq!(app.task_row("TASK-1").await.column, Column::InProgress);
+}
+
+#[tokio::test]
+async fn prioritize_across_columns_errors() {
+    let app = seeded_with_two_tasks_in_different_columns().await;
+    let err = app
+        .task_reorder(&cli_actor(), "TASK-1", Some("TASK-2"), None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "different_column");
+}
+
+#[tokio::test]
+async fn blank_title_is_validation_error() {
+    let app = seeded().await;
+    let err = app
+        .task_create(
+            &cli_actor(),
+            TaskCreate {
+                project_slug: "renai-sim".into(),
+                title: "  ".into(),
+                column: None,
+                urgent: false,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+    match err {
+        AppError::Validation { field, .. } => assert_eq!(field, "title"),
+        other => panic!("expected validation_error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn display_ids_never_reuse() {
+    let app = seeded().await;
+    create_task(&app, "A", None, false).await;
+    create_task(&app, "B", None, false).await;
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-1", "TASK-2"]);
+}
+
+#[tokio::test]
+async fn new_non_urgent_cards_go_at_end_of_non_urgent_group() {
+    let app = seeded().await;
+    create_task(&app, "Urgent first", None, true).await;
+    create_task(&app, "Normal A", None, false).await;
+    create_task(&app, "Normal B", None, false).await;
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-1", "TASK-2", "TASK-3"]);
+    assert!(listed[0].urgent);
+    assert!(!listed[1].urgent);
+    assert!(!listed[2].urgent);
+    assert_eq!(app.task_row("TASK-1").await.position, 0);
+    assert_eq!(app.task_row("TASK-2").await.position, 1);
+    assert_eq!(app.task_row("TASK-3").await.position, 2);
+}
+
+#[tokio::test]
+async fn new_urgent_card_goes_at_end_of_urgent_group() {
+    let app = seeded().await;
+    create_task(&app, "Normal A", None, false).await;
+    create_task(&app, "Urgent first", None, true).await;
+    create_task(&app, "Urgent second", None, true).await;
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-2", "TASK-3", "TASK-1"]);
+    assert_eq!(app.task_row("TASK-2").await.position, 0);
+    assert_eq!(app.task_row("TASK-3").await.position, 1);
+    assert_eq!(app.task_row("TASK-1").await.position, 2);
+}
+
+#[tokio::test]
+async fn task_list_sorts_urgent_then_position_and_is_idle() {
+    let app = seeded().await;
+    create_task(&app, "Later non-urgent", None, false).await;
+    create_task(&app, "Urgent", None, true).await;
+    let listed = app.task_list("renai-sim").await.unwrap();
+    assert_eq!(listed[0].display_id, "TASK-2");
+    assert_eq!(listed[1].display_id, "TASK-1");
+    assert!(listed
+        .iter()
+        .all(|t| t.display_status == CardDisplayStatus::Idle));
+    assert!(listed.iter().all(|t| t.run_message.is_none()));
+}
+
+#[tokio::test]
+async fn task_show_includes_empty_links_runs_and_create_activity() {
+    let app = seeded().await;
+    create_task(&app, "Fix login error", None, false).await;
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert!(shown.links.is_empty());
+    assert!(shown.runs.is_empty());
+    assert_eq!(shown.recent_activities.len(), 1);
+    assert_eq!(shown.recent_activities[0].operation, "task.create");
+    assert_eq!(shown.display_status, CardDisplayStatus::Idle);
+}
+
+#[tokio::test]
+async fn create_on_deleted_project_is_not_found() {
+    let app = seeded().await;
+    app.project_delete(&cli_actor(), "renai-sim", None)
+        .await
+        .unwrap();
+    let err = app
+        .task_create(
+            &cli_actor(),
+            TaskCreate {
+                project_slug: "renai-sim".into(),
+                title: "Orphan".into(),
+                column: None,
+                urgent: false,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "not_found");
+}
+
+#[tokio::test]
+async fn task_update_trims_title_and_checks_revision() {
+    let app = seeded().await;
+    create_task(&app, "Fix login error", None, false).await;
+    let updated = app
+        .task_update(
+            &cli_actor(),
+            TaskUpdate {
+                display_id: "TASK-1".into(),
+                title: Some("  Trimmed title  ".into()),
+                revision: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.title, "Trimmed title");
+    assert_eq!(updated.revision, 2);
+    assert_eq!(updated.recent_activities[0].operation, "task.update");
+
+    let err = app
+        .task_update(
+            &cli_actor(),
+            TaskUpdate {
+                display_id: "TASK-1".into(),
+                title: Some("Nope".into()),
+                revision: Some(1),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "revision_conflict");
+}
+
+#[tokio::test]
+async fn task_update_blank_title_is_validation_error() {
+    let app = seeded().await;
+    create_task(&app, "Keep me", None, false).await;
+    let err = app
+        .task_update(
+            &cli_actor(),
+            TaskUpdate {
+                display_id: "TASK-1".into(),
+                title: Some("   ".into()),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+    match err {
+        AppError::Validation { field, .. } => assert_eq!(field, "title"),
+        other => panic!("expected validation_error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn task_reorder_before_none_moves_to_end() {
+    let app = seeded().await;
+    create_task(&app, "A", None, false).await;
+    create_task(&app, "B", None, false).await;
+    create_task(&app, "C", None, false).await;
+    app.task_reorder(&cli_actor(), "TASK-1", None, None)
+        .await
+        .unwrap();
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-2", "TASK-3", "TASK-1"]);
+    assert_eq!(app.task_row("TASK-2").await.position, 0);
+    assert_eq!(app.task_row("TASK-3").await.position, 1);
+    assert_eq!(app.task_row("TASK-1").await.position, 2);
+}
+
+#[tokio::test]
+async fn task_reorder_places_before_target() {
+    let app = seeded().await;
+    create_task(&app, "A", None, false).await;
+    create_task(&app, "B", None, false).await;
+    create_task(&app, "C", None, false).await;
+    let reordered = app
+        .task_reorder(&cli_actor(), "TASK-3", Some("TASK-1"), None)
+        .await
+        .unwrap();
+    assert_eq!(reordered.recent_activities[0].operation, "task.reorder");
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-3", "TASK-1", "TASK-2"]);
+}
+
+#[tokio::test]
+async fn task_urgent_on_moves_to_end_of_urgent_group() {
+    let app = seeded().await;
+    create_task(&app, "Urgent", None, true).await;
+    create_task(&app, "Normal", None, false).await;
+    let toggled = app
+        .task_urgent(&cli_actor(), "TASK-2", true, None)
+        .await
+        .unwrap();
+    assert!(toggled.urgent);
+    assert_eq!(toggled.recent_activities[0].operation, "task.urgent");
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-1", "TASK-2"]);
+    assert_eq!(app.task_row("TASK-1").await.position, 0);
+    assert_eq!(app.task_row("TASK-2").await.position, 1);
+}
+
+#[tokio::test]
+async fn task_urgent_off_moves_to_start_of_non_urgent_group() {
+    let app = seeded().await;
+    create_task(&app, "U1", None, true).await;
+    create_task(&app, "U2", None, true).await;
+    create_task(&app, "N1", None, false).await;
+    app.task_urgent(&cli_actor(), "TASK-1", false, None)
+        .await
+        .unwrap();
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-2", "TASK-1", "TASK-3"]);
+    assert!(!listed[1].urgent);
+    assert_eq!(app.task_row("TASK-2").await.position, 0);
+    assert_eq!(app.task_row("TASK-1").await.position, 1);
+    assert_eq!(app.task_row("TASK-3").await.position, 2);
+}
+
+#[tokio::test]
+async fn task_move_records_move_activity() {
+    let app = seeded_with_two_tasks().await;
+    let moved = app
+        .task_move(&cli_actor(), "TASK-1", Column::Done, None)
+        .await
+        .unwrap();
+    assert_eq!(moved.column, Column::Done);
+    assert_eq!(moved.recent_activities[0].operation, "task.move");
+}

--- a/crates/store-sqlite/src/store.rs
+++ b/crates/store-sqlite/src/store.rs
@@ -5,12 +5,17 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Row, SqlitePool};
 use taskboard_application::{AppError, NewActivity, Store};
-use taskboard_core::{Activity, ActorKind, Column, EntityType, Link, Project, Run, Task};
+use taskboard_core::{
+    Activity, ActorKind, Column, EntityType, Link, LinkKind, Project, Run, RunStatus, Task,
+};
 use uuid::Uuid;
 
 use crate::db::map_sqlx;
 
 const PROJECT_COLUMNS: &str = "id, slug, name, repo_path, archived, note_markdown, sort_order, revision, created_at, updated_at, deleted_at";
+const TASK_COLUMNS: &str = "id, display_id, project_id, title, column, urgent, note_markdown, position, revision, created_at, updated_at, deleted_at";
+const LINK_COLUMNS: &str = "id, task_id, kind, value, sort_order";
+const RUN_COLUMNS: &str = "id, display_id, task_id, agent, session_id, status, message, waiting_reason, summary, started_at, ended_at, revision, created_at, updated_at";
 const ACTIVITY_COLUMNS: &str = "id, sequence, actor_kind, actor_label, operation, entity_type, entity_id, previous_revision, before_json, after_json, created_at";
 
 macro_rules! run {
@@ -126,6 +131,69 @@ fn activity_from_row(row: &SqliteRow) -> Result<Activity, AppError> {
             .transpose()
             .map_err(|err| AppError::Io(err.to_string()))?,
         created_at: parse_dt(&created_at)?,
+    })
+}
+
+fn task_from_row(row: &SqliteRow) -> Result<Task, AppError> {
+    let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+    let project_id: Vec<u8> = row.try_get("project_id").map_err(map_sqlx)?;
+    let column: String = row.try_get("column").map_err(map_sqlx)?;
+    let urgent: i64 = row.try_get("urgent").map_err(map_sqlx)?;
+    let created_at: String = row.try_get("created_at").map_err(map_sqlx)?;
+    let updated_at: String = row.try_get("updated_at").map_err(map_sqlx)?;
+    let deleted_at: Option<String> = row.try_get("deleted_at").map_err(map_sqlx)?;
+    Ok(Task {
+        id: uuid_from_blob(&id)?,
+        display_id: row.try_get("display_id").map_err(map_sqlx)?,
+        project_id: uuid_from_blob(&project_id)?,
+        title: row.try_get("title").map_err(map_sqlx)?,
+        column: parse_enum(&column)?,
+        urgent: urgent != 0,
+        note_markdown: row.try_get("note_markdown").map_err(map_sqlx)?,
+        position: row.try_get("position").map_err(map_sqlx)?,
+        revision: row.try_get("revision").map_err(map_sqlx)?,
+        created_at: parse_dt(&created_at)?,
+        updated_at: parse_dt(&updated_at)?,
+        deleted_at: deleted_at.as_deref().map(parse_dt).transpose()?,
+    })
+}
+
+fn link_from_row(row: &SqliteRow) -> Result<Link, AppError> {
+    let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+    let task_id: Vec<u8> = row.try_get("task_id").map_err(map_sqlx)?;
+    let kind: String = row.try_get("kind").map_err(map_sqlx)?;
+    Ok(Link {
+        id: uuid_from_blob(&id)?,
+        task_id: uuid_from_blob(&task_id)?,
+        kind: parse_enum::<LinkKind>(&kind)?,
+        value: row.try_get("value").map_err(map_sqlx)?,
+        sort_order: row.try_get("sort_order").map_err(map_sqlx)?,
+    })
+}
+
+fn run_from_row(row: &SqliteRow) -> Result<Run, AppError> {
+    let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+    let task_id: Vec<u8> = row.try_get("task_id").map_err(map_sqlx)?;
+    let status: String = row.try_get("status").map_err(map_sqlx)?;
+    let started_at: String = row.try_get("started_at").map_err(map_sqlx)?;
+    let ended_at: Option<String> = row.try_get("ended_at").map_err(map_sqlx)?;
+    let created_at: String = row.try_get("created_at").map_err(map_sqlx)?;
+    let updated_at: String = row.try_get("updated_at").map_err(map_sqlx)?;
+    Ok(Run {
+        id: uuid_from_blob(&id)?,
+        display_id: row.try_get("display_id").map_err(map_sqlx)?,
+        task_id: uuid_from_blob(&task_id)?,
+        agent: row.try_get("agent").map_err(map_sqlx)?,
+        session_id: row.try_get("session_id").map_err(map_sqlx)?,
+        status: parse_enum::<RunStatus>(&status)?,
+        message: row.try_get("message").map_err(map_sqlx)?,
+        waiting_reason: row.try_get("waiting_reason").map_err(map_sqlx)?,
+        summary: row.try_get("summary").map_err(map_sqlx)?,
+        started_at: parse_dt(&started_at)?,
+        ended_at: ended_at.as_deref().map(parse_dt).transpose()?,
+        revision: row.try_get("revision").map_err(map_sqlx)?,
+        created_at: parse_dt(&created_at)?,
+        updated_at: parse_dt(&updated_at)?,
     })
 }
 
@@ -272,61 +340,139 @@ impl Store for SqliteStore {
         Ok(())
     }
 
-    async fn get_task(&mut self, _id: Uuid) -> Result<Option<Task>, AppError> {
-        Err(not_impl("get_task"))
+    async fn get_task(&mut self, id: Uuid) -> Result<Option<Task>, AppError> {
+        let sql = format!("SELECT {TASK_COLUMNS} FROM tasks WHERE id = ?");
+        let query = sqlx::query(&sql).bind(uuid_bytes(id));
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(task_from_row).transpose()
     }
 
     async fn get_task_by_display_id(
         &mut self,
-        _display_id: &str,
-        _include_deleted: bool,
+        display_id: &str,
+        include_deleted: bool,
     ) -> Result<Option<Task>, AppError> {
-        Err(not_impl("get_task_by_display_id"))
+        let sql = if include_deleted {
+            format!(
+                "SELECT {TASK_COLUMNS} FROM tasks WHERE display_id = ? ORDER BY CASE WHEN deleted_at IS NULL THEN 0 ELSE 1 END, deleted_at DESC LIMIT 1"
+            )
+        } else {
+            format!("SELECT {TASK_COLUMNS} FROM tasks WHERE display_id = ? AND deleted_at IS NULL")
+        };
+        let query = sqlx::query(&sql).bind(display_id);
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(task_from_row).transpose()
     }
 
-    async fn list_tasks(&mut self, _project_id: Uuid) -> Result<Vec<Task>, AppError> {
-        Err(not_impl("list_tasks"))
+    async fn list_tasks(&mut self, project_id: Uuid) -> Result<Vec<Task>, AppError> {
+        let sql = format!(
+            "SELECT {TASK_COLUMNS} FROM tasks WHERE project_id = ? AND deleted_at IS NULL ORDER BY urgent DESC, position ASC"
+        );
+        let query = sqlx::query(&sql).bind(uuid_bytes(project_id));
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(task_from_row).collect()
     }
 
     async fn list_deleted_tasks(&mut self) -> Result<Vec<Task>, AppError> {
-        Err(not_impl("list_deleted_tasks"))
+        let sql = format!(
+            "SELECT {TASK_COLUMNS} FROM tasks WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC"
+        );
+        let query = sqlx::query(&sql);
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(task_from_row).collect()
     }
 
-    async fn insert_task(&mut self, _task: &Task) -> Result<(), AppError> {
-        Err(not_impl("insert_task"))
+    async fn insert_task(&mut self, task: &Task) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "INSERT INTO tasks (id, display_id, project_id, title, column, urgent, note_markdown, position, revision, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(uuid_bytes(task.id))
+        .bind(&task.display_id)
+        .bind(uuid_bytes(task.project_id))
+        .bind(&task.title)
+        .bind(enum_str(task.column)?)
+        .bind(if task.urgent { 1i64 } else { 0 })
+        .bind(&task.note_markdown)
+        .bind(task.position)
+        .bind(task.revision)
+        .bind(fmt_dt(task.created_at))
+        .bind(fmt_dt(task.updated_at))
+        .bind(task.deleted_at.map(fmt_dt));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn update_task(&mut self, _task: &Task) -> Result<(), AppError> {
-        Err(not_impl("update_task"))
+    async fn update_task(&mut self, task: &Task) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "UPDATE tasks SET display_id = ?, project_id = ?, title = ?, column = ?, urgent = ?, note_markdown = ?, position = ?, revision = ?, created_at = ?, updated_at = ?, deleted_at = ? WHERE id = ?",
+        )
+        .bind(&task.display_id)
+        .bind(uuid_bytes(task.project_id))
+        .bind(&task.title)
+        .bind(enum_str(task.column)?)
+        .bind(if task.urgent { 1i64 } else { 0 })
+        .bind(&task.note_markdown)
+        .bind(task.position)
+        .bind(task.revision)
+        .bind(fmt_dt(task.created_at))
+        .bind(fmt_dt(task.updated_at))
+        .bind(task.deleted_at.map(fmt_dt))
+        .bind(uuid_bytes(task.id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
     async fn soft_delete_task(
         &mut self,
-        _id: Uuid,
-        _deleted_at: DateTime<Utc>,
+        id: Uuid,
+        deleted_at: DateTime<Utc>,
     ) -> Result<(), AppError> {
-        Err(not_impl("soft_delete_task"))
+        let query = sqlx::query("UPDATE tasks SET deleted_at = ? WHERE id = ?")
+            .bind(fmt_dt(deleted_at))
+            .bind(uuid_bytes(id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn restore_task(&mut self, _id: Uuid) -> Result<(), AppError> {
-        Err(not_impl("restore_task"))
+    async fn restore_task(&mut self, id: Uuid) -> Result<(), AppError> {
+        let query =
+            sqlx::query("UPDATE tasks SET deleted_at = NULL WHERE id = ?").bind(uuid_bytes(id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
     async fn rewrite_task_positions(
         &mut self,
-        _project_id: Uuid,
-        _column: Column,
-        _ordered_ids: &[Uuid],
+        project_id: Uuid,
+        column: Column,
+        ordered_ids: &[Uuid],
     ) -> Result<(), AppError> {
-        Err(not_impl("rewrite_task_positions"))
+        let column = enum_str(column)?;
+        let negate = sqlx::query(
+            "UPDATE tasks SET position = -(position + 1) WHERE project_id = ? AND column = ? AND deleted_at IS NULL",
+        )
+        .bind(uuid_bytes(project_id))
+        .bind(&column);
+        run!(self, negate, execute).map_err(map_sqlx)?;
+        for (index, id) in ordered_ids.iter().enumerate() {
+            let query = sqlx::query("UPDATE tasks SET position = ? WHERE id = ?")
+                .bind(index as i64)
+                .bind(uuid_bytes(*id));
+            run!(self, query, execute).map_err(map_sqlx)?;
+        }
+        Ok(())
     }
 
     async fn get_link(&mut self, _id: Uuid) -> Result<Option<Link>, AppError> {
         Err(not_impl("get_link"))
     }
 
-    async fn list_links(&mut self, _task_id: Uuid) -> Result<Vec<Link>, AppError> {
-        Err(not_impl("list_links"))
+    async fn list_links(&mut self, task_id: Uuid) -> Result<Vec<Link>, AppError> {
+        let sql =
+            format!("SELECT {LINK_COLUMNS} FROM links WHERE task_id = ? ORDER BY sort_order ASC");
+        let query = sqlx::query(&sql).bind(uuid_bytes(task_id));
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(link_from_row).collect()
     }
 
     async fn insert_link(&mut self, _link: &Link) -> Result<(), AppError> {
@@ -349,8 +495,13 @@ impl Store for SqliteStore {
         Err(not_impl("get_run_by_display_id"))
     }
 
-    async fn list_runs(&mut self, _task_id: Uuid) -> Result<Vec<Run>, AppError> {
-        Err(not_impl("list_runs"))
+    async fn list_runs(&mut self, task_id: Uuid) -> Result<Vec<Run>, AppError> {
+        let sql = format!(
+            "SELECT {RUN_COLUMNS} FROM runs WHERE task_id = ? ORDER BY started_at DESC, display_id DESC"
+        );
+        let query = sqlx::query(&sql).bind(uuid_bytes(task_id));
+        let rows = run!(self, query, fetch_all).map_err(map_sqlx)?;
+        rows.iter().map(run_from_row).collect()
     }
 
     async fn insert_run(&mut self, _run: &Run) -> Result<(), AppError> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #10

Plan 1 Task 8: task create, list, show, update, move, reorder, and urgent, with two-phase SQLite position rewrites.

Verify: `cargo test -p taskboard-application --test tasks` (17 passed) and `--test projects` (16 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

