### PR TITLE
feat: add notes, links, and agent runs

### DIFF
--- a/crates/application/src/app.rs
+++ b/crates/application/src/app.rs
@@ -3,14 +3,18 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use taskboard_core::{
-    card_display_status, display_id, next_unique_slug, place_before, place_urgent,
-    rewrite_positions, slugify, sort_column, trim_project_name, trim_title, Column, DisplayKind,
-    EntityType, FieldError, OrderError, OrderKey, Project, RunStatusView, SlugError, Task,
-    TaskDetail, TaskSummary, ValidationError,
+    card_display_status, display_id, next_unique_slug, parse_agent, parse_path_link, parse_url,
+    place_before, place_urgent, rewrite_positions, slugify, sort_column, trim_project_name,
+    trim_title, Column, DisplayKind, EntityType, FieldError, Link, LinkKind, OrderError, OrderKey,
+    Project, Run, RunStatus, RunStatusView, SlugError, Task, TaskDetail, TaskSummary,
+    ValidationError,
 };
 
 use crate::actor::Actor;
-use crate::commands::{ProjectAdd, ProjectUpdate, TaskCreate, TaskUpdate};
+use crate::commands::{
+    LinkAdd, ProjectAdd, ProjectUpdate, RunFail, RunFinish, RunStart, RunUpdate, RunWait,
+    TaskCreate, TaskUpdate,
+};
 use crate::error::AppError;
 use crate::store::{NewActivity, Store};
 
@@ -226,6 +230,104 @@ impl App {
         let store = &mut **store;
         store.begin().await?;
         let result = task_urgent_inner(store, actor, display_id, urgent, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_note_set(
+        &self,
+        actor: &Actor,
+        display_id: &str,
+        markdown: String,
+        revision: Option<i64>,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_note_set_inner(store, actor, display_id, markdown, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_note_add(
+        &self,
+        actor: &Actor,
+        display_id: &str,
+        paragraph: &str,
+        revision: Option<i64>,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_note_add_inner(store, actor, display_id, paragraph, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn link_add(&self, actor: &Actor, cmd: LinkAdd) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = link_add_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn link_remove(
+        &self,
+        actor: &Actor,
+        link_id: Uuid,
+        revision: Option<i64>,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = link_remove_inner(store, actor, link_id, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn run_start(&self, actor: &Actor, cmd: RunStart) -> Result<Run, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = run_start_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn run_update(&self, actor: &Actor, cmd: RunUpdate) -> Result<Run, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = run_update_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn run_wait(&self, actor: &Actor, cmd: RunWait) -> Result<Run, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = run_wait_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn run_fail(&self, actor: &Actor, cmd: RunFail) -> Result<Run, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = run_fail_inner(store, actor, cmd, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn run_finish(&self, actor: &Actor, cmd: RunFinish) -> Result<Run, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = run_finish_inner(store, actor, cmd, now).await;
         commit_or_rollback(store, result).await
     }
 }
@@ -821,6 +923,383 @@ async fn task_urgent_inner(
     load_task_detail(store, task).await
 }
 
+async fn task_note_set_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    markdown: String,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    write_task_note(store, actor, display_id, markdown, revision, now).await
+}
+
+async fn task_note_add_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    paragraph: &str,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let paragraph = require_non_blank("paragraph", paragraph)?;
+    let task = require_live_task(store, display_id).await?;
+    let markdown = if task.note_markdown.is_empty() {
+        paragraph
+    } else {
+        format!("{}\n\n{paragraph}", task.note_markdown)
+    };
+    write_task_note(store, actor, display_id, markdown, revision, now).await
+}
+
+async fn write_task_note(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    markdown: String,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = require_live_task(store, display_id).await?;
+    check_revision(&task, task.revision, revision)?;
+    let before = task.clone();
+    task.note_markdown = markdown;
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.note.set",
+            entity_id: task.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn link_add_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: LinkAdd,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = require_live_task(store, &cmd.task_display_id).await?;
+    check_revision(&task, task.revision, cmd.revision)?;
+    let value = match cmd.kind {
+        LinkKind::Url => parse_url(&cmd.value).map_err(map_validation)?,
+        LinkKind::Path => parse_path_link(&cmd.value).map_err(map_validation)?,
+    };
+    let existing = store.list_links(task.id).await?;
+    let sort_order = existing
+        .iter()
+        .map(|link| link.sort_order)
+        .max()
+        .map(|max| max + 1)
+        .unwrap_or(0);
+    let link = Link {
+        id: Uuid::now_v7(),
+        task_id: task.id,
+        kind: cmd.kind,
+        value,
+        sort_order,
+    };
+    store.insert_link(&link).await?;
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Link,
+            operation: "link.add",
+            entity_id: link.id,
+            previous_revision: None,
+            before_json: None,
+            after_json: Some(json_value(&link)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn link_remove_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    link_id: Uuid,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let link = store
+        .get_link(link_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound {
+            entity: "link".into(),
+            id: link_id.to_string(),
+        })?;
+    let mut task = store
+        .get_task(link.task_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound {
+            entity: "task".into(),
+            id: link.task_id.to_string(),
+        })?;
+    if task.deleted_at.is_some() {
+        return Err(AppError::NotFound {
+            entity: "task".into(),
+            id: task.display_id,
+        });
+    }
+    check_revision(&task, task.revision, revision)?;
+    store.delete_link(link.id).await?;
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Link,
+            operation: "link.remove",
+            entity_id: link.id,
+            previous_revision: None,
+            before_json: Some(json_value(&link)?),
+            after_json: None,
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn run_start_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: RunStart,
+    now: DateTime<Utc>,
+) -> Result<Run, AppError> {
+    let task = require_live_task(store, &cmd.task_display_id).await?;
+    let agent = parse_agent(&cmd.agent).map_err(map_validation)?;
+    let session_id = parse_session_id(cmd.session_id)?;
+    let n = store.next_display_n("run").await?;
+    let run = Run {
+        id: Uuid::now_v7(),
+        display_id: display_id(DisplayKind::Run, n),
+        task_id: task.id,
+        agent,
+        session_id,
+        status: RunStatus::Running,
+        message: None,
+        waiting_reason: None,
+        summary: None,
+        started_at: now,
+        ended_at: None,
+        revision: 1,
+        created_at: now,
+        updated_at: now,
+    };
+    store.insert_run(&run).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Run,
+            operation: "run.start",
+            entity_id: run.id,
+            previous_revision: None,
+            before_json: None,
+            after_json: Some(json_value(&run)?),
+        },
+    )
+    .await?;
+    Ok(run)
+}
+
+async fn run_update_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: RunUpdate,
+    now: DateTime<Utc>,
+) -> Result<Run, AppError> {
+    mutate_run(
+        store,
+        actor,
+        &cmd.run_display_id,
+        cmd.revision,
+        now,
+        "run.update",
+        |run| {
+            if let Some(message) = cmd.message {
+                run.message = Some(parse_run_message(&message)?);
+            }
+            Ok(())
+        },
+    )
+    .await
+}
+
+async fn run_wait_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: RunWait,
+    now: DateTime<Utc>,
+) -> Result<Run, AppError> {
+    let reason = require_non_blank("reason", &cmd.reason)?;
+    mutate_run(
+        store,
+        actor,
+        &cmd.run_display_id,
+        cmd.revision,
+        now,
+        "run.wait",
+        |run| {
+            run.status = RunStatus::Waiting;
+            run.waiting_reason = Some(reason);
+            Ok(())
+        },
+    )
+    .await
+}
+
+async fn run_fail_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: RunFail,
+    now: DateTime<Utc>,
+) -> Result<Run, AppError> {
+    let summary = require_non_blank("summary", &cmd.summary)?;
+    mutate_run(
+        store,
+        actor,
+        &cmd.run_display_id,
+        cmd.revision,
+        now,
+        "run.fail",
+        |run| {
+            run.status = RunStatus::Failed;
+            run.summary = Some(summary);
+            run.ended_at = Some(now);
+            Ok(())
+        },
+    )
+    .await
+}
+
+async fn run_finish_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    cmd: RunFinish,
+    now: DateTime<Utc>,
+) -> Result<Run, AppError> {
+    let summary = require_non_blank("summary", &cmd.summary)?;
+    mutate_run(
+        store,
+        actor,
+        &cmd.run_display_id,
+        cmd.revision,
+        now,
+        "run.finish",
+        |run| {
+            run.status = RunStatus::Completed;
+            run.summary = Some(summary);
+            run.ended_at = Some(now);
+            Ok(())
+        },
+    )
+    .await
+}
+
+async fn mutate_run<F>(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+    operation: &'static str,
+    mutate: F,
+) -> Result<Run, AppError>
+where
+    F: FnOnce(&mut Run) -> Result<(), AppError>,
+{
+    let mut run = require_run(store, display_id).await?;
+    check_revision(&run, run.revision, revision)?;
+    let before = run.clone();
+    mutate(&mut run)?;
+    run.revision += 1;
+    run.updated_at = now;
+    store.update_run(&run).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Run,
+            operation,
+            entity_id: run.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&run)?),
+        },
+    )
+    .await?;
+    Ok(run)
+}
+
+async fn require_run(store: &mut dyn Store, display_id: &str) -> Result<Run, AppError> {
+    store
+        .get_run_by_display_id(display_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound {
+            entity: "run".into(),
+            id: display_id.to_string(),
+        })
+}
+
+fn require_non_blank(field: &str, raw: &str) -> Result<String, AppError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Validation {
+            field: field.to_string(),
+            message: "must not be empty".into(),
+        });
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_session_id(session_id: Option<String>) -> Result<Option<String>, AppError> {
+    match session_id {
+        None => Ok(None),
+        Some(raw) => {
+            if raw.chars().count() > 128 {
+                return Err(AppError::Validation {
+                    field: "session_id".into(),
+                    message: "must be at most 128 characters".into(),
+                });
+            }
+            Ok(Some(raw))
+        }
+    }
+}
+
+fn parse_run_message(raw: &str) -> Result<String, AppError> {
+    if raw.chars().count() > 500 {
+        return Err(AppError::Validation {
+            field: "message".into(),
+            message: "must be at most 500 characters".into(),
+        });
+    }
+    Ok(raw.to_string())
+}
+
 async fn require_live_task(store: &mut dyn Store, display_id: &str) -> Result<Task, AppError> {
     store
         .get_task_by_display_id(display_id, false)
@@ -933,9 +1412,7 @@ async fn to_task_summary(store: &mut dyn Store, task: Task) -> Result<TaskSummar
     })
 }
 
-fn display_from_runs(
-    runs: &[taskboard_core::Run],
-) -> (taskboard_core::CardDisplayStatus, Option<String>) {
+fn display_from_runs(runs: &[Run]) -> (taskboard_core::CardDisplayStatus, Option<String>) {
     let views: Vec<RunStatusView> = runs
         .iter()
         .map(|run| RunStatusView {
@@ -945,8 +1422,12 @@ fn display_from_runs(
         })
         .collect();
     let display_status = card_display_status(&views);
+    let has_active = runs
+        .iter()
+        .any(|run| matches!(run.status, RunStatus::Running | RunStatus::Waiting));
     let run_message = runs
         .iter()
+        .filter(|run| !has_active || matches!(run.status, RunStatus::Running | RunStatus::Waiting))
         .max_by(|left, right| {
             left.started_at
                 .cmp(&right.started_at)

--- a/crates/application/tests/notes_runs.rs
+++ b/crates/application/tests/notes_runs.rs
@@ -1,0 +1,660 @@
+use std::ops::Deref;
+
+use taskboard_application::{
+    Actor, App, AppError, LinkAdd, ProjectAdd, RunFail, RunFinish, RunStart, RunUpdate, RunWait,
+    Store, SystemClock, TaskCreate,
+};
+use taskboard_core::{ActorKind, CardDisplayStatus, Column, LinkKind, Run, RunStatus, Task};
+use taskboard_store_sqlite::{open_db, SqliteStore};
+use uuid::Uuid;
+
+struct TestApp {
+    app: App,
+    _tmp: tempfile::TempDir,
+}
+
+impl TestApp {
+    async fn task_row(&self, display_id: &str) -> Task {
+        let pool = open_db(self._tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool);
+        store
+            .get_task_by_display_id(display_id, false)
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    async fn latest_activity_for(&self, entity_id: Uuid) -> taskboard_core::Activity {
+        let pool = open_db(self._tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool);
+        store.latest_activity_for(entity_id).await.unwrap().unwrap()
+    }
+
+    async fn get_run(&self, display_id: &str) -> Run {
+        let pool = open_db(self._tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool);
+        store
+            .get_run_by_display_id(display_id)
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    async fn get_link(&self, id: Uuid) -> Option<taskboard_core::Link> {
+        let pool = open_db(self._tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool);
+        store.get_link(id).await.unwrap()
+    }
+
+    async fn soft_delete_task(&self, display_id: &str) {
+        let pool = open_db(self._tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool);
+        let task = store
+            .get_task_by_display_id(display_id, false)
+            .await
+            .unwrap()
+            .unwrap();
+        store
+            .soft_delete_task(task.id, chrono::Utc::now())
+            .await
+            .unwrap();
+    }
+}
+
+impl Deref for TestApp {
+    type Target = App;
+
+    fn deref(&self) -> &Self::Target {
+        &self.app
+    }
+}
+
+fn cli_actor() -> Actor {
+    Actor {
+        kind: ActorKind::Cli,
+        label: "local-cli".into(),
+    }
+}
+
+async fn test_app() -> TestApp {
+    let tmp = tempfile::tempdir().unwrap();
+    let pool = open_db(tmp.path()).await.unwrap();
+    let store = SqliteStore::new(pool);
+    TestApp {
+        app: App::new(store, SystemClock),
+        _tmp: tmp,
+    }
+}
+
+async fn seeded() -> TestApp {
+    let app = test_app().await;
+    app.project_add(
+        &cli_actor(),
+        ProjectAdd {
+            name: "Renai Sim".into(),
+            repo_path: None,
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+    app
+}
+
+async fn seeded_task() -> TestApp {
+    let app = seeded().await;
+    app.task_create(
+        &cli_actor(),
+        TaskCreate {
+            project_slug: "renai-sim".into(),
+            title: "Fix login error".into(),
+            column: None,
+            urgent: false,
+        },
+    )
+    .await
+    .unwrap();
+    app
+}
+
+async fn seeded_running() -> TestApp {
+    let app = seeded_task().await;
+    app.run_start(
+        &cli_actor(),
+        RunStart {
+            task_display_id: "TASK-1".into(),
+            agent: "codex".into(),
+            session_id: Some("abc123".into()),
+        },
+    )
+    .await
+    .unwrap();
+    app
+}
+
+#[tokio::test]
+async fn note_add_appends_paragraph() {
+    let app = seeded_task().await;
+    app.task_note_set(&cli_actor(), "TASK-1", "First".into(), None)
+        .await
+        .unwrap();
+    let t = app
+        .task_note_add(&cli_actor(), "TASK-1", "Second", None)
+        .await
+        .unwrap();
+    assert_eq!(t.note_markdown, "First\n\nSecond");
+}
+
+#[tokio::test]
+async fn run_start_returns_run_1_running() {
+    let app = seeded_task().await;
+    let r = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "codex".into(),
+                session_id: Some("abc123".into()),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.display_id, "RUN-1");
+    assert_eq!(r.status, RunStatus::Running);
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.display_status, CardDisplayStatus::Running);
+    assert_eq!(shown.column, Column::Todo);
+}
+
+#[tokio::test]
+async fn finish_does_not_move_column() {
+    let app = seeded_running().await;
+    app.run_finish(
+        &cli_actor(),
+        RunFinish {
+            run_display_id: "RUN-1".into(),
+            summary: "done".into(),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.column, Column::Todo);
+    assert_eq!(shown.display_status, CardDisplayStatus::Completed);
+}
+
+#[tokio::test]
+async fn wait_requires_reason() {
+    let app = seeded_running().await;
+    let err = app
+        .run_wait(
+            &cli_actor(),
+            RunWait {
+                run_display_id: "RUN-1".into(),
+                reason: " ".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+}
+
+#[tokio::test]
+async fn note_add_on_empty_note_is_just_the_paragraph() {
+    let app = seeded_task().await;
+    let t = app
+        .task_note_add(&cli_actor(), "TASK-1", "Only paragraph", None)
+        .await
+        .unwrap();
+    assert_eq!(t.note_markdown, "Only paragraph");
+}
+
+#[tokio::test]
+async fn note_add_empty_paragraph_is_validation_error() {
+    let app = seeded_task().await;
+    let err = app
+        .task_note_add(&cli_actor(), "TASK-1", "   ", None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+}
+
+#[tokio::test]
+async fn note_set_keeps_malformed_markdown() {
+    let app = seeded_task().await;
+    let markdown = "[unclosed](http://example.com".to_string();
+    let t = app
+        .task_note_set(&cli_actor(), "TASK-1", markdown.clone(), None)
+        .await
+        .unwrap();
+    assert_eq!(t.note_markdown, markdown);
+    assert_eq!(t.revision, 2);
+    assert_eq!(t.recent_activities[0].operation, "task.note.set");
+}
+
+#[tokio::test]
+async fn note_add_records_task_note_set_activity() {
+    let app = seeded_task().await;
+    let t = app
+        .task_note_add(&cli_actor(), "TASK-1", "Check sessions", None)
+        .await
+        .unwrap();
+    assert_eq!(t.recent_activities[0].operation, "task.note.set");
+}
+
+#[tokio::test]
+async fn link_add_url_and_path_sort_order_per_task() {
+    let app = seeded_task().await;
+    let first = app
+        .link_add(
+            &cli_actor(),
+            LinkAdd {
+                task_display_id: "TASK-1".into(),
+                kind: LinkKind::Url,
+                value: "https://example.com".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.links.len(), 1);
+    assert_eq!(first.links[0].kind, LinkKind::Url);
+    assert_eq!(first.links[0].value, "https://example.com");
+    assert_eq!(first.links[0].sort_order, 0);
+    assert_eq!(
+        app.latest_activity_for(first.links[0].id).await.operation,
+        "link.add"
+    );
+
+    let second = app
+        .link_add(
+            &cli_actor(),
+            LinkAdd {
+                task_display_id: "TASK-1".into(),
+                kind: LinkKind::Path,
+                value: "/tmp/does-not-need-to-exist.log".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.links.len(), 2);
+    assert_eq!(second.links[0].sort_order, 0);
+    assert_eq!(second.links[1].kind, LinkKind::Path);
+    assert_eq!(second.links[1].value, "/tmp/does-not-need-to-exist.log");
+    assert_eq!(second.links[1].sort_order, 1);
+}
+
+#[tokio::test]
+async fn link_add_invalid_url_is_validation_error() {
+    let app = seeded_task().await;
+    let err = app
+        .link_add(
+            &cli_actor(),
+            LinkAdd {
+                task_display_id: "TASK-1".into(),
+                kind: LinkKind::Url,
+                value: "ftp://x".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+    match err {
+        AppError::Validation { field, .. } => assert_eq!(field, "value"),
+        other => panic!("expected validation_error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn link_remove_deletes_by_id() {
+    let app = seeded_task().await;
+    let added = app
+        .link_add(
+            &cli_actor(),
+            LinkAdd {
+                task_display_id: "TASK-1".into(),
+                kind: LinkKind::Url,
+                value: "https://example.com".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap();
+    let link_id = added.links[0].id;
+    let removed = app.link_remove(&cli_actor(), link_id, None).await.unwrap();
+    assert!(removed.links.is_empty());
+    assert_eq!(
+        app.latest_activity_for(link_id).await.operation,
+        "link.remove"
+    );
+    assert!(app.get_link(link_id).await.is_none());
+}
+
+#[tokio::test]
+async fn link_remove_missing_is_not_found() {
+    let app = seeded_task().await;
+    let err = app
+        .link_remove(&cli_actor(), Uuid::nil(), None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "not_found");
+}
+
+#[tokio::test]
+async fn run_start_on_deleted_task_is_not_found() {
+    let app = seeded_task().await;
+    app.soft_delete_task("TASK-1").await;
+    let err = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "codex".into(),
+                session_id: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "not_found");
+}
+
+#[tokio::test]
+async fn run_start_invalid_agent_is_validation_error() {
+    let app = seeded_task().await;
+    let err = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "Claude".into(),
+                session_id: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+    match err {
+        AppError::Validation { field, .. } => assert_eq!(field, "agent"),
+        other => panic!("expected validation_error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn concurrent_runs_are_allowed() {
+    let app = seeded_task().await;
+    let first = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "codex".into(),
+                session_id: Some("a".into()),
+            },
+        )
+        .await
+        .unwrap();
+    let second = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "codex".into(),
+                session_id: Some("b".into()),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.display_id, "RUN-1");
+    assert_eq!(second.display_id, "RUN-2");
+    assert_eq!(first.status, RunStatus::Running);
+    assert_eq!(second.status, RunStatus::Running);
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.runs.len(), 2);
+    assert_eq!(shown.display_status, CardDisplayStatus::Running);
+    assert_eq!(shown.column, Column::Todo);
+}
+
+#[tokio::test]
+async fn run_update_sets_message_and_rejects_over_500() {
+    let app = seeded_running().await;
+    let updated = app
+        .run_update(
+            &cli_actor(),
+            RunUpdate {
+                run_display_id: "RUN-1".into(),
+                message: Some("compiling".into()),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.message.as_deref(), Some("compiling"));
+    assert_eq!(
+        app.latest_activity_for(updated.id).await.operation,
+        "run.update"
+    );
+
+    let err = app
+        .run_update(
+            &cli_actor(),
+            RunUpdate {
+                run_display_id: "RUN-1".into(),
+                message: Some("x".repeat(501)),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "validation_error");
+}
+
+#[tokio::test]
+async fn run_wait_sets_waiting_reason() {
+    let app = seeded_running().await;
+    let waiting = app
+        .run_wait(
+            &cli_actor(),
+            RunWait {
+                run_display_id: "RUN-1".into(),
+                reason: "need review".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(waiting.status, RunStatus::Waiting);
+    assert_eq!(waiting.waiting_reason.as_deref(), Some("need review"));
+    assert!(waiting.ended_at.is_none());
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.display_status, CardDisplayStatus::Waiting);
+    assert_eq!(shown.column, Column::Todo);
+    assert_eq!(
+        app.latest_activity_for(waiting.id).await.operation,
+        "run.wait"
+    );
+}
+
+#[tokio::test]
+async fn run_fail_sets_ended_at_and_does_not_move_column() {
+    let app = seeded_running().await;
+    let failed = app
+        .run_fail(
+            &cli_actor(),
+            RunFail {
+                run_display_id: "RUN-1".into(),
+                summary: "boom".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(failed.status, RunStatus::Failed);
+    assert_eq!(failed.summary.as_deref(), Some("boom"));
+    assert!(failed.ended_at.is_some());
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.column, Column::Todo);
+    assert_eq!(shown.display_status, CardDisplayStatus::Failed);
+    assert_eq!(app.task_row("TASK-1").await.column, Column::Todo);
+    assert_eq!(
+        app.latest_activity_for(failed.id).await.operation,
+        "run.fail"
+    );
+}
+
+#[tokio::test]
+async fn run_fail_and_finish_require_summary() {
+    let app = seeded_running().await;
+    let fail_err = app
+        .run_fail(
+            &cli_actor(),
+            RunFail {
+                run_display_id: "RUN-1".into(),
+                summary: "  ".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(fail_err.code(), "validation_error");
+
+    let finish_err = app
+        .run_finish(
+            &cli_actor(),
+            RunFinish {
+                run_display_id: "RUN-1".into(),
+                summary: "".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(finish_err.code(), "validation_error");
+}
+
+#[tokio::test]
+async fn finish_records_run_finish_and_ended_at() {
+    let app = seeded_running().await;
+    let finished = app
+        .run_finish(
+            &cli_actor(),
+            RunFinish {
+                run_display_id: "RUN-1".into(),
+                summary: "done".into(),
+                revision: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(finished.status, RunStatus::Completed);
+    assert!(finished.ended_at.is_some());
+    let stored = app.get_run("RUN-1").await;
+    assert!(stored.ended_at.is_some());
+    assert_eq!(stored.status, RunStatus::Completed);
+    assert_eq!(
+        app.latest_activity_for(finished.id).await.operation,
+        "run.finish"
+    );
+    assert_eq!(
+        app.latest_activity_for(finished.id).await.entity_type,
+        taskboard_core::EntityType::Run
+    );
+}
+
+#[tokio::test]
+async fn run_message_matches_display_status_run() {
+    let app = seeded_task().await;
+    let older = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "codex".into(),
+                session_id: None,
+            },
+        )
+        .await
+        .unwrap();
+    app.run_update(
+        &cli_actor(),
+        RunUpdate {
+            run_display_id: older.display_id.clone(),
+            message: Some("please review".into()),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    app.run_wait(
+        &cli_actor(),
+        RunWait {
+            run_display_id: "RUN-1".into(),
+            reason: "review".into(),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    let newer = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "codex".into(),
+                session_id: None,
+            },
+        )
+        .await
+        .unwrap();
+    app.run_update(
+        &cli_actor(),
+        RunUpdate {
+            run_display_id: newer.display_id.clone(),
+            message: Some("finished work".into()),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    app.run_finish(
+        &cli_actor(),
+        RunFinish {
+            run_display_id: "RUN-2".into(),
+            summary: "done".into(),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let listed = app.task_list("renai-sim").await.unwrap();
+    assert_eq!(listed[0].display_status, CardDisplayStatus::Waiting);
+    assert_eq!(listed[0].run_message.as_deref(), Some("please review"));
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.display_status, CardDisplayStatus::Waiting);
+    assert_eq!(shown.run_message.as_deref(), Some("please review"));
+}
+
+#[tokio::test]
+async fn run_start_records_run_start_activity() {
+    let app = seeded_task().await;
+    let r = app
+        .run_start(
+            &cli_actor(),
+            RunStart {
+                task_display_id: "TASK-1".into(),
+                agent: "codex".into(),
+                session_id: Some("abc123".into()),
+            },
+        )
+        .await
+        .unwrap();
+    let activity = app.latest_activity_for(r.id).await;
+    assert_eq!(activity.operation, "run.start");
+    assert_eq!(r.agent, "codex");
+    assert_eq!(r.session_id.as_deref(), Some("abc123"));
+    assert_eq!(r.revision, 1);
+}

--- a/crates/store-sqlite/src/store.rs
+++ b/crates/store-sqlite/src/store.rs
@@ -463,8 +463,11 @@ impl Store for SqliteStore {
         Ok(())
     }
 
-    async fn get_link(&mut self, _id: Uuid) -> Result<Option<Link>, AppError> {
-        Err(not_impl("get_link"))
+    async fn get_link(&mut self, id: Uuid) -> Result<Option<Link>, AppError> {
+        let sql = format!("SELECT {LINK_COLUMNS} FROM links WHERE id = ?");
+        let query = sqlx::query(&sql).bind(uuid_bytes(id));
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(link_from_row).transpose()
     }
 
     async fn list_links(&mut self, task_id: Uuid) -> Result<Vec<Link>, AppError> {
@@ -475,24 +478,50 @@ impl Store for SqliteStore {
         rows.iter().map(link_from_row).collect()
     }
 
-    async fn insert_link(&mut self, _link: &Link) -> Result<(), AppError> {
-        Err(not_impl("insert_link"))
+    async fn insert_link(&mut self, link: &Link) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "INSERT INTO links (id, task_id, kind, value, sort_order) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(uuid_bytes(link.id))
+        .bind(uuid_bytes(link.task_id))
+        .bind(enum_str(link.kind)?)
+        .bind(&link.value)
+        .bind(link.sort_order);
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn update_link(&mut self, _link: &Link) -> Result<(), AppError> {
-        Err(not_impl("update_link"))
+    async fn update_link(&mut self, link: &Link) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "UPDATE links SET task_id = ?, kind = ?, value = ?, sort_order = ? WHERE id = ?",
+        )
+        .bind(uuid_bytes(link.task_id))
+        .bind(enum_str(link.kind)?)
+        .bind(&link.value)
+        .bind(link.sort_order)
+        .bind(uuid_bytes(link.id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn delete_link(&mut self, _id: Uuid) -> Result<(), AppError> {
-        Err(not_impl("delete_link"))
+    async fn delete_link(&mut self, id: Uuid) -> Result<(), AppError> {
+        let query = sqlx::query("DELETE FROM links WHERE id = ?").bind(uuid_bytes(id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn get_run(&mut self, _id: Uuid) -> Result<Option<Run>, AppError> {
-        Err(not_impl("get_run"))
+    async fn get_run(&mut self, id: Uuid) -> Result<Option<Run>, AppError> {
+        let sql = format!("SELECT {RUN_COLUMNS} FROM runs WHERE id = ?");
+        let query = sqlx::query(&sql).bind(uuid_bytes(id));
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(run_from_row).transpose()
     }
 
-    async fn get_run_by_display_id(&mut self, _display_id: &str) -> Result<Option<Run>, AppError> {
-        Err(not_impl("get_run_by_display_id"))
+    async fn get_run_by_display_id(&mut self, display_id: &str) -> Result<Option<Run>, AppError> {
+        let sql = format!("SELECT {RUN_COLUMNS} FROM runs WHERE display_id = ?");
+        let query = sqlx::query(&sql).bind(display_id);
+        let row = run!(self, query, fetch_optional).map_err(map_sqlx)?;
+        row.as_ref().map(run_from_row).transpose()
     }
 
     async fn list_runs(&mut self, task_id: Uuid) -> Result<Vec<Run>, AppError> {
@@ -504,16 +533,54 @@ impl Store for SqliteStore {
         rows.iter().map(run_from_row).collect()
     }
 
-    async fn insert_run(&mut self, _run: &Run) -> Result<(), AppError> {
-        Err(not_impl("insert_run"))
+    async fn insert_run(&mut self, run: &Run) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "INSERT INTO runs (id, display_id, task_id, agent, session_id, status, message, waiting_reason, summary, started_at, ended_at, revision, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(uuid_bytes(run.id))
+        .bind(&run.display_id)
+        .bind(uuid_bytes(run.task_id))
+        .bind(&run.agent)
+        .bind(&run.session_id)
+        .bind(enum_str(run.status)?)
+        .bind(&run.message)
+        .bind(&run.waiting_reason)
+        .bind(&run.summary)
+        .bind(fmt_dt(run.started_at))
+        .bind(run.ended_at.map(fmt_dt))
+        .bind(run.revision)
+        .bind(fmt_dt(run.created_at))
+        .bind(fmt_dt(run.updated_at));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn update_run(&mut self, _run: &Run) -> Result<(), AppError> {
-        Err(not_impl("update_run"))
+    async fn update_run(&mut self, run: &Run) -> Result<(), AppError> {
+        let query = sqlx::query(
+            "UPDATE runs SET display_id = ?, task_id = ?, agent = ?, session_id = ?, status = ?, message = ?, waiting_reason = ?, summary = ?, started_at = ?, ended_at = ?, revision = ?, created_at = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(&run.display_id)
+        .bind(uuid_bytes(run.task_id))
+        .bind(&run.agent)
+        .bind(&run.session_id)
+        .bind(enum_str(run.status)?)
+        .bind(&run.message)
+        .bind(&run.waiting_reason)
+        .bind(&run.summary)
+        .bind(fmt_dt(run.started_at))
+        .bind(run.ended_at.map(fmt_dt))
+        .bind(run.revision)
+        .bind(fmt_dt(run.created_at))
+        .bind(fmt_dt(run.updated_at))
+        .bind(uuid_bytes(run.id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn delete_run(&mut self, _id: Uuid) -> Result<(), AppError> {
-        Err(not_impl("delete_run"))
+    async fn delete_run(&mut self, id: Uuid) -> Result<(), AppError> {
+        let query = sqlx::query("DELETE FROM runs WHERE id = ?").bind(uuid_bytes(id));
+        run!(self, query, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
     async fn activity_head(&mut self) -> Result<i64, AppError> {
@@ -659,6 +726,86 @@ mod tests {
         assert_eq!(id_type, "blob");
         assert_eq!(id_len, 16);
         assert_eq!(created_at, "2026-09-05T12:00:00.000Z");
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn link_and_run_insert_update_get_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = crate::open_db(tmp.path()).await.unwrap();
+        let mut store = SqliteStore::new(pool.clone());
+        let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+        let project = Project {
+            id: Uuid::now_v7(),
+            slug: "renai-sim".into(),
+            name: "Renai Sim".into(),
+            repo_path: None,
+            archived: false,
+            note_markdown: String::new(),
+            sort_order: 0,
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.insert_project(&project).await.unwrap();
+        let task = Task {
+            id: Uuid::now_v7(),
+            display_id: "TASK-1".into(),
+            project_id: project.id,
+            title: "Fix".into(),
+            column: Column::Todo,
+            urgent: false,
+            note_markdown: String::new(),
+            position: 0,
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.insert_task(&task).await.unwrap();
+
+        let mut link = Link {
+            id: Uuid::now_v7(),
+            task_id: task.id,
+            kind: LinkKind::Url,
+            value: "https://example.com".into(),
+            sort_order: 0,
+        };
+        store.insert_link(&link).await.unwrap();
+        link.value = "https://example.com/updated".into();
+        store.update_link(&link).await.unwrap();
+        let loaded = store.get_link(link.id).await.unwrap().unwrap();
+        assert_eq!(loaded.value, "https://example.com/updated");
+        store.delete_link(link.id).await.unwrap();
+        assert!(store.get_link(link.id).await.unwrap().is_none());
+
+        let mut run = Run {
+            id: Uuid::now_v7(),
+            display_id: "RUN-1".into(),
+            task_id: task.id,
+            agent: "codex".into(),
+            session_id: Some("abc".into()),
+            status: RunStatus::Running,
+            message: None,
+            waiting_reason: None,
+            summary: None,
+            started_at: now,
+            ended_at: None,
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+        };
+        store.insert_run(&run).await.unwrap();
+        run.status = RunStatus::Completed;
+        run.summary = Some("done".into());
+        run.ended_at = Some(now);
+        store.update_run(&run).await.unwrap();
+        let loaded = store.get_run_by_display_id("RUN-1").await.unwrap().unwrap();
+        assert_eq!(loaded.status, RunStatus::Completed);
+        assert_eq!(store.get_run(run.id).await.unwrap().unwrap().id, run.id);
+        store.delete_run(run.id).await.unwrap();
+        assert!(store.get_run(run.id).await.unwrap().is_none());
         pool.close().await;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #11

Plan 1 Task 9: Markdown notes, URL/path links, and multiple agent runs per card. Finishing a run does not move the card.

Verify: `cargo test -p taskboard-application --test notes_runs` (22 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

