### PR TITLE
feat: add revisions, trash, undo, and backups

### DIFF
--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -15,5 +15,6 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+chrono.workspace = true
 tempfile = "=3.19.1"
 taskboard-store-sqlite = { path = "../store-sqlite" }

--- a/crates/application/src/app.rs
+++ b/crates/application/src/app.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use chrono::{DateTime, Utc};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -5,8 +7,8 @@ use uuid::Uuid;
 use taskboard_core::{
     card_display_status, display_id, next_unique_slug, parse_agent, parse_path_link, parse_url,
     place_before, place_urgent, rewrite_positions, slugify, sort_column, trim_project_name,
-    trim_title, Column, DisplayKind, EntityType, FieldError, Link, LinkKind, OrderError, OrderKey,
-    Project, Run, RunStatus, RunStatusView, SlugError, Task, TaskDetail, TaskSummary,
+    trim_title, Activity, Column, DisplayKind, EntityType, FieldError, Link, LinkKind, OrderError,
+    OrderKey, Project, Run, RunStatus, RunStatusView, SlugError, Task, TaskDetail, TaskSummary,
     ValidationError,
 };
 
@@ -16,7 +18,7 @@ use crate::commands::{
     TaskCreate, TaskUpdate,
 };
 use crate::error::AppError;
-use crate::store::{NewActivity, Store};
+use crate::store::{NewActivity, Store, SyncDelta, Trash, UndoResult};
 
 pub trait Clock: Send + Sync {
     fn now(&self) -> DateTime<Utc>;
@@ -329,6 +331,83 @@ impl App {
         store.begin().await?;
         let result = run_finish_inner(store, actor, cmd, now).await;
         commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_delete(
+        &self,
+        actor: &Actor,
+        display_id: &str,
+        revision: Option<i64>,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_delete_inner(store, actor, display_id, revision, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn task_restore(
+        &self,
+        actor: &Actor,
+        display_id: &str,
+    ) -> Result<TaskDetail, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = task_restore_inner(store, actor, display_id, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn trash_list(&self) -> Result<Trash, AppError> {
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        let projects = store.list_deleted_projects().await?;
+        let deleted_tasks = store.list_deleted_tasks().await?;
+        let mut tasks = Vec::with_capacity(deleted_tasks.len());
+        for task in deleted_tasks {
+            tasks.push(to_task_summary(store, task).await?);
+        }
+        Ok(Trash { projects, tasks })
+    }
+
+    pub async fn purge_expired_trash(&self, now: DateTime<Utc>) -> Result<u64, AppError> {
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = store.purge_expired(now, 30).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn undo(&self, actor: &Actor) -> Result<UndoResult, AppError> {
+        let now = self.clock.now();
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        store.begin().await?;
+        let result = undo_inner(store, actor, now).await;
+        commit_or_rollback(store, result).await
+    }
+
+    pub async fn activity_head(&self) -> Result<i64, AppError> {
+        let mut store = self.store.lock().await;
+        store.activity_head().await
+    }
+
+    pub async fn sync(&self, after: i64) -> Result<SyncDelta, AppError> {
+        let mut store = self.store.lock().await;
+        let store = &mut **store;
+        sync_inner(store, after).await
+    }
+
+    pub async fn backup_export(&self, dest: &Path) -> Result<(), AppError> {
+        let mut store = self.store.lock().await;
+        store.backup_to(dest).await
+    }
+
+    pub async fn backup_import(&self, src: &Path) -> Result<(), AppError> {
+        let mut store = self.store.lock().await;
+        store.replace_from(src).await
     }
 }
 
@@ -984,6 +1063,74 @@ async fn write_task_note(
     load_task_detail(store, task).await
 }
 
+async fn task_delete_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    revision: Option<i64>,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = require_live_task(store, display_id).await?;
+    check_revision(&task, task.revision, revision)?;
+    let before = task.clone();
+    task.deleted_at = Some(now);
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    rewrite_live_column(store, before.project_id, before.column).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.delete",
+            entity_id: task.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
+async fn task_restore_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    display_id: &str,
+    now: DateTime<Utc>,
+) -> Result<TaskDetail, AppError> {
+    let mut task = store
+        .get_task_by_display_id(display_id, true)
+        .await?
+        .ok_or_else(|| task_not_found(display_id))?;
+    if task.deleted_at.is_none() {
+        return Err(task_not_found(display_id));
+    }
+    let before = task.clone();
+    task.deleted_at = None;
+    assign_unique_task_position(store, &mut task).await?;
+    task.revision += 1;
+    task.updated_at = now;
+    store.update_task(&task).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: EntityType::Task,
+            operation: "task.restore",
+            entity_id: task.id,
+            previous_revision: Some(before.revision),
+            before_json: Some(json_value(&before)?),
+            after_json: Some(json_value(&task)?),
+        },
+    )
+    .await?;
+    load_task_detail(store, task).await
+}
+
 async fn link_add_inner(
     store: &mut dyn Store,
     actor: &Actor,
@@ -1374,6 +1521,22 @@ async fn rewrite_column(
         .await
 }
 
+async fn rewrite_live_column(
+    store: &mut dyn Store,
+    project_id: Uuid,
+    column: Column,
+) -> Result<(), AppError> {
+    let column_tasks: Vec<Task> = store
+        .list_tasks(project_id)
+        .await?
+        .into_iter()
+        .filter(|item| item.column == column)
+        .collect();
+    let mut keys = task_keys(&column_tasks);
+    rewrite_positions(&mut keys);
+    rewrite_column(store, project_id, column, &keys, &column_tasks).await
+}
+
 async fn load_task_detail(store: &mut dyn Store, task: Task) -> Result<TaskDetail, AppError> {
     let links = store.list_links(task.id).await?;
     let runs = store.list_runs(task.id).await?;
@@ -1507,6 +1670,333 @@ async fn record_activity(
             created_at: now,
         })
         .await
+}
+
+async fn undo_inner(
+    store: &mut dyn Store,
+    actor: &Actor,
+    now: DateTime<Utc>,
+) -> Result<UndoResult, AppError> {
+    let undoable = store
+        .latest_undoable()
+        .await?
+        .ok_or_else(|| AppError::NotFound {
+            entity: "activity".into(),
+            id: "undo".into(),
+        })?;
+    let latest = store.latest_activity_for(undoable.entity_id).await?;
+    if latest
+        .as_ref()
+        .is_some_and(|activity| activity.sequence > undoable.sequence)
+    {
+        return Err(AppError::UndoConflict {
+            current: current_entity_json(store, undoable.entity_type, undoable.entity_id).await?,
+        });
+    }
+    let entity = apply_compensation(store, &undoable, now).await?;
+    record_activity(
+        store,
+        actor,
+        now,
+        ActivityWrite {
+            entity_type: undoable.entity_type,
+            operation: "undo",
+            entity_id: undoable.entity_id,
+            previous_revision: undoable.previous_revision,
+            before_json: undoable.after_json.clone(),
+            after_json: Some(entity.clone()),
+        },
+    )
+    .await?;
+    Ok(UndoResult {
+        entity_type: undoable.entity_type,
+        entity,
+    })
+}
+
+async fn apply_compensation(
+    store: &mut dyn Store,
+    activity: &Activity,
+    now: DateTime<Utc>,
+) -> Result<serde_json::Value, AppError> {
+    if activity.operation == "project.reorder" {
+        return compensate_project_reorder(store, activity).await;
+    }
+    if activity.before_json.is_none() {
+        return compensate_create(store, activity, now).await;
+    }
+    if activity.operation == "link.remove" {
+        let link: Link = serde_json::from_value(
+            activity
+                .before_json
+                .clone()
+                .ok_or_else(|| AppError::Io("link.remove missing before_json".into()))?,
+        )
+        .map_err(map_json)?;
+        store.insert_link(&link).await?;
+        return json_value(&link);
+    }
+    restore_snapshot(store, activity).await
+}
+
+async fn compensate_create(
+    store: &mut dyn Store,
+    activity: &Activity,
+    now: DateTime<Utc>,
+) -> Result<serde_json::Value, AppError> {
+    match activity.entity_type {
+        EntityType::Task => {
+            let mut task =
+                store
+                    .get_task(activity.entity_id)
+                    .await?
+                    .ok_or_else(|| AppError::NotFound {
+                        entity: "task".into(),
+                        id: activity.entity_id.to_string(),
+                    })?;
+            task.deleted_at = Some(now);
+            task.revision += 1;
+            task.updated_at = now;
+            store.update_task(&task).await?;
+            json_value(&task)
+        }
+        EntityType::Project => {
+            let mut project = store
+                .get_project(activity.entity_id)
+                .await?
+                .ok_or_else(|| AppError::NotFound {
+                    entity: "project".into(),
+                    id: activity.entity_id.to_string(),
+                })?;
+            project.deleted_at = Some(now);
+            project.revision += 1;
+            project.updated_at = now;
+            store.update_project(&project).await?;
+            json_value(&project)
+        }
+        EntityType::Link => {
+            let link = store.get_link(activity.entity_id).await?;
+            store.delete_link(activity.entity_id).await?;
+            match link {
+                Some(link) => json_value(&link),
+                None => Ok(serde_json::Value::Null),
+            }
+        }
+        EntityType::Run => {
+            let run = store.get_run(activity.entity_id).await?;
+            store.delete_run(activity.entity_id).await?;
+            match run {
+                Some(run) => json_value(&run),
+                None => Ok(serde_json::Value::Null),
+            }
+        }
+    }
+}
+
+async fn restore_snapshot(
+    store: &mut dyn Store,
+    activity: &Activity,
+) -> Result<serde_json::Value, AppError> {
+    let before = activity
+        .before_json
+        .clone()
+        .ok_or_else(|| AppError::Io("activity missing before_json".into()))?;
+    match activity.entity_type {
+        EntityType::Task => {
+            let mut task: Task = serde_json::from_value(before).map_err(map_json)?;
+            assign_unique_task_position(store, &mut task).await?;
+            store.update_task(&task).await?;
+            json_value(&task)
+        }
+        EntityType::Project => {
+            let mut project: Project = serde_json::from_value(before).map_err(map_json)?;
+            assign_unique_project_sort(store, &mut project).await?;
+            store.update_project(&project).await?;
+            json_value(&project)
+        }
+        EntityType::Link => {
+            let link: Link = serde_json::from_value(before).map_err(map_json)?;
+            store.update_link(&link).await?;
+            json_value(&link)
+        }
+        EntityType::Run => {
+            let run: Run = serde_json::from_value(before).map_err(map_json)?;
+            store.update_run(&run).await?;
+            json_value(&run)
+        }
+    }
+}
+
+async fn compensate_project_reorder(
+    store: &mut dyn Store,
+    activity: &Activity,
+) -> Result<serde_json::Value, AppError> {
+    let before: Vec<Project> = serde_json::from_value(
+        activity
+            .before_json
+            .clone()
+            .ok_or_else(|| AppError::Io("project.reorder missing before_json".into()))?,
+    )
+    .map_err(map_json)?;
+    let ids: Vec<Uuid> = before.iter().map(|project| project.id).collect();
+    store.rewrite_project_sort_orders(&ids).await?;
+    for project in &before {
+        store.update_project(project).await?;
+    }
+    json_value(&before)
+}
+
+async fn assign_unique_task_position(
+    store: &mut dyn Store,
+    task: &mut Task,
+) -> Result<(), AppError> {
+    if task.deleted_at.is_some() {
+        return Ok(());
+    }
+    let taken: std::collections::HashSet<i64> = store
+        .list_tasks(task.project_id)
+        .await?
+        .into_iter()
+        .filter(|item| item.column == task.column && item.id != task.id)
+        .map(|item| item.position)
+        .collect();
+    if taken.contains(&task.position) {
+        task.position = taken.iter().max().copied().unwrap_or(-1) + 1;
+    }
+    Ok(())
+}
+
+async fn assign_unique_project_sort(
+    store: &mut dyn Store,
+    project: &mut Project,
+) -> Result<(), AppError> {
+    if project.deleted_at.is_some() {
+        return Ok(());
+    }
+    let taken: std::collections::HashSet<i64> = store
+        .list_projects(true)
+        .await?
+        .into_iter()
+        .filter(|item| item.id != project.id)
+        .map(|item| item.sort_order)
+        .collect();
+    if taken.contains(&project.sort_order) {
+        project.sort_order = taken.iter().max().copied().unwrap_or(-1) + 1;
+    }
+    Ok(())
+}
+
+async fn current_entity_json(
+    store: &mut dyn Store,
+    entity_type: EntityType,
+    entity_id: Uuid,
+) -> Result<serde_json::Value, AppError> {
+    match entity_type {
+        EntityType::Project => match store.get_project(entity_id).await? {
+            Some(project) => json_value(&project),
+            None => Ok(serde_json::Value::Null),
+        },
+        EntityType::Task => match store.get_task(entity_id).await? {
+            Some(task) => json_value(&task),
+            None => Ok(serde_json::Value::Null),
+        },
+        EntityType::Link => match store.get_link(entity_id).await? {
+            Some(link) => json_value(&link),
+            None => Ok(serde_json::Value::Null),
+        },
+        EntityType::Run => match store.get_run(entity_id).await? {
+            Some(run) => json_value(&run),
+            None => Ok(serde_json::Value::Null),
+        },
+    }
+}
+
+async fn sync_inner(store: &mut dyn Store, after: i64) -> Result<SyncDelta, AppError> {
+    let activities = store.list_activities_after(after).await?;
+    let sequence = store.activity_head().await?;
+    let mut project_ids = Vec::new();
+    let mut task_ids = Vec::new();
+    let mut run_ids = Vec::new();
+    let mut seen_projects = std::collections::HashSet::new();
+    let mut seen_tasks = std::collections::HashSet::new();
+    let mut seen_runs = std::collections::HashSet::new();
+
+    for activity in activities {
+        match activity.entity_type {
+            EntityType::Project => {
+                if seen_projects.insert(activity.entity_id) {
+                    project_ids.push(activity.entity_id);
+                }
+            }
+            EntityType::Task => {
+                if seen_tasks.insert(activity.entity_id) {
+                    task_ids.push(activity.entity_id);
+                }
+            }
+            EntityType::Run => {
+                if seen_runs.insert(activity.entity_id) {
+                    run_ids.push(activity.entity_id);
+                }
+            }
+            EntityType::Link => {
+                if let Some(task_id) = link_task_id(store, &activity).await? {
+                    if seen_tasks.insert(task_id) {
+                        task_ids.push(task_id);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut projects = Vec::new();
+    for id in project_ids {
+        if let Some(project) = store.get_project(id).await? {
+            projects.push(project);
+        }
+    }
+    let mut tasks = Vec::new();
+    for id in task_ids {
+        if let Some(task) = store.get_task(id).await? {
+            tasks.push(load_task_detail(store, task).await?);
+        }
+    }
+    let mut runs = Vec::new();
+    for id in run_ids {
+        if let Some(run) = store.get_run(id).await? {
+            runs.push(run);
+        }
+    }
+    Ok(SyncDelta {
+        sequence,
+        projects,
+        tasks,
+        runs,
+    })
+}
+
+async fn link_task_id(
+    store: &mut dyn Store,
+    activity: &Activity,
+) -> Result<Option<Uuid>, AppError> {
+    if let Some(link) = store.get_link(activity.entity_id).await? {
+        return Ok(Some(link.task_id));
+    }
+    for payload in [&activity.after_json, &activity.before_json]
+        .into_iter()
+        .flatten()
+    {
+        if let Some(task_id) = uuid_from_json(payload, "task_id") {
+            return Ok(Some(task_id));
+        }
+    }
+    Ok(None)
+}
+
+fn uuid_from_json(value: &serde_json::Value, key: &str) -> Option<Uuid> {
+    value
+        .get(key)
+        .and_then(|item| item.as_str())
+        .and_then(|raw| Uuid::parse_str(raw).ok())
 }
 
 fn json_value<T: serde::Serialize>(value: &T) -> Result<serde_json::Value, AppError> {

--- a/crates/application/src/app.rs
+++ b/crates/application/src/app.rs
@@ -407,7 +407,19 @@ impl App {
 
     pub async fn backup_import(&self, src: &Path) -> Result<(), AppError> {
         let mut store = self.store.lock().await;
-        store.replace_from(src).await
+        let store = &mut **store;
+        store.validate_import(src).await?;
+        let pre = store.pre_import_path()?;
+        store.backup_to(&pre).await?;
+        store.close_pool().await?;
+        let copied = store.replace_from(src).await;
+        let reopened = store.reopen_pool().await;
+        match (copied, reopened) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(err), Ok(())) => Err(err),
+            (Ok(()), Err(err)) => Err(err),
+            (Err(err), Err(_)) => Err(err),
+        }
     }
 }
 
@@ -1693,6 +1705,7 @@ async fn undo_inner(
             current: current_entity_json(store, undoable.entity_type, undoable.entity_id).await?,
         });
     }
+    let previous_revision = revision_just_undone(store, &undoable).await?;
     let entity = apply_compensation(store, &undoable, now).await?;
     record_activity(
         store,
@@ -1702,7 +1715,7 @@ async fn undo_inner(
             entity_type: undoable.entity_type,
             operation: "undo",
             entity_id: undoable.entity_id,
-            previous_revision: undoable.previous_revision,
+            previous_revision,
             before_json: undoable.after_json.clone(),
             after_json: Some(entity.clone()),
         },
@@ -1736,7 +1749,28 @@ async fn apply_compensation(
         store.insert_link(&link).await?;
         return json_value(&link);
     }
-    restore_snapshot(store, activity).await
+    restore_snapshot(store, activity, now).await
+}
+
+async fn revision_just_undone(
+    store: &mut dyn Store,
+    activity: &Activity,
+) -> Result<Option<i64>, AppError> {
+    match activity.entity_type {
+        EntityType::Task => Ok(store
+            .get_task(activity.entity_id)
+            .await?
+            .map(|task| task.revision)),
+        EntityType::Project => Ok(store
+            .get_project(activity.entity_id)
+            .await?
+            .map(|project| project.revision)),
+        EntityType::Run => Ok(store
+            .get_run(activity.entity_id)
+            .await?
+            .map(|run| run.revision)),
+        EntityType::Link => Ok(None),
+    }
 }
 
 async fn compensate_create(
@@ -1758,6 +1792,7 @@ async fn compensate_create(
             task.revision += 1;
             task.updated_at = now;
             store.update_task(&task).await?;
+            rewrite_live_column(store, task.project_id, task.column).await?;
             json_value(&task)
         }
         EntityType::Project => {
@@ -1796,6 +1831,7 @@ async fn compensate_create(
 async fn restore_snapshot(
     store: &mut dyn Store,
     activity: &Activity,
+    now: DateTime<Utc>,
 ) -> Result<serde_json::Value, AppError> {
     let before = activity
         .before_json
@@ -1803,14 +1839,33 @@ async fn restore_snapshot(
         .ok_or_else(|| AppError::Io("activity missing before_json".into()))?;
     match activity.entity_type {
         EntityType::Task => {
+            let current =
+                store
+                    .get_task(activity.entity_id)
+                    .await?
+                    .ok_or_else(|| AppError::NotFound {
+                        entity: "task".into(),
+                        id: activity.entity_id.to_string(),
+                    })?;
             let mut task: Task = serde_json::from_value(before).map_err(map_json)?;
             assign_unique_task_position(store, &mut task).await?;
+            task.revision = current.revision + 1;
+            task.updated_at = now;
             store.update_task(&task).await?;
             json_value(&task)
         }
         EntityType::Project => {
+            let current = store
+                .get_project(activity.entity_id)
+                .await?
+                .ok_or_else(|| AppError::NotFound {
+                    entity: "project".into(),
+                    id: activity.entity_id.to_string(),
+                })?;
             let mut project: Project = serde_json::from_value(before).map_err(map_json)?;
             assign_unique_project_sort(store, &mut project).await?;
+            project.revision = current.revision + 1;
+            project.updated_at = now;
             store.update_project(&project).await?;
             json_value(&project)
         }
@@ -1820,7 +1875,17 @@ async fn restore_snapshot(
             json_value(&link)
         }
         EntityType::Run => {
-            let run: Run = serde_json::from_value(before).map_err(map_json)?;
+            let current =
+                store
+                    .get_run(activity.entity_id)
+                    .await?
+                    .ok_or_else(|| AppError::NotFound {
+                        entity: "run".into(),
+                        id: activity.entity_id.to_string(),
+                    })?;
+            let mut run: Run = serde_json::from_value(before).map_err(map_json)?;
+            run.revision = current.revision + 1;
+            run.updated_at = now;
             store.update_run(&run).await?;
             json_value(&run)
         }

--- a/crates/application/src/store.rs
+++ b/crates/application/src/store.rs
@@ -132,6 +132,11 @@ pub trait Store: Send + Sync {
         retention_days: i64,
     ) -> Result<u64, AppError>;
     async fn backup_to(&mut self, dest: &Path) -> Result<(), AppError>;
+    async fn validate_import(&mut self, src: &Path) -> Result<(), AppError>;
+    fn pre_import_path(&self) -> Result<std::path::PathBuf, AppError>;
+    async fn close_pool(&mut self) -> Result<(), AppError>;
+    async fn reopen_pool(&mut self) -> Result<(), AppError>;
+    /// Copy `src` over the live SQLite file. Caller must have closed the pool.
     async fn replace_from(&mut self, src: &Path) -> Result<(), AppError>;
     async fn begin(&mut self) -> Result<(), AppError>;
     async fn commit(&mut self) -> Result<(), AppError>;

--- a/crates/application/tests/concurrency.rs
+++ b/crates/application/tests/concurrency.rs
@@ -1,0 +1,312 @@
+use std::ops::Deref;
+use std::time::{Duration, Instant};
+
+use chrono::{Duration as ChronoDuration, Utc};
+use taskboard_application::{Actor, App, ProjectAdd, Store, SystemClock, TaskCreate, TaskUpdate};
+use taskboard_core::{ActorKind, Column};
+use taskboard_store_sqlite::{open_db, SqliteStore};
+
+struct TestApp {
+    app: App,
+    tmp: tempfile::TempDir,
+}
+
+impl Deref for TestApp {
+    type Target = App;
+
+    fn deref(&self) -> &Self::Target {
+        &self.app
+    }
+}
+
+fn cli_actor() -> Actor {
+    Actor {
+        kind: ActorKind::Cli,
+        label: "local-cli".into(),
+    }
+}
+
+async fn test_app() -> TestApp {
+    let tmp = tempfile::tempdir().unwrap();
+    let pool = open_db(tmp.path()).await.unwrap();
+    let store = SqliteStore::with_data_dir(pool, tmp.path().to_path_buf());
+    TestApp {
+        app: App::new(store, SystemClock),
+        tmp,
+    }
+}
+
+async fn seeded_task() -> TestApp {
+    let app = test_app().await;
+    app.project_add(
+        &cli_actor(),
+        ProjectAdd {
+            name: "Renai Sim".into(),
+            repo_path: None,
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+    app.task_create(
+        &cli_actor(),
+        TaskCreate {
+            project_slug: "renai-sim".into(),
+            title: "Fix login error".into(),
+            column: None,
+            urgent: false,
+        },
+    )
+    .await
+    .unwrap();
+    app
+}
+
+#[tokio::test]
+async fn stale_revision_does_not_write() {
+    let app = seeded_task().await;
+    let err = app
+        .task_update(
+            &cli_actor(),
+            TaskUpdate {
+                display_id: "TASK-1".into(),
+                title: Some("Nope".into()),
+                revision: Some(0),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "revision_conflict");
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.title, "Fix login error");
+}
+
+#[tokio::test]
+async fn delete_hides_then_restore() {
+    let app = seeded_task().await;
+    app.task_delete(&cli_actor(), "TASK-1", None).await.unwrap();
+    assert!(app.task_show("TASK-1").await.is_err());
+    let trash = app.trash_list().await.unwrap();
+    assert_eq!(trash.tasks[0].display_id, "TASK-1");
+    app.task_restore(&cli_actor(), "TASK-1").await.unwrap();
+    assert_eq!(
+        app.task_show("TASK-1").await.unwrap().title,
+        "Fix login error"
+    );
+}
+
+#[tokio::test]
+async fn purge_after_thirty_days() {
+    let app = seeded_task().await;
+    app.task_delete(&cli_actor(), "TASK-1", None).await.unwrap();
+    let later = Utc::now() + ChronoDuration::days(31);
+    let n = app.purge_expired_trash(later).await.unwrap();
+    assert!(n >= 1);
+    let trash = app.trash_list().await.unwrap();
+    assert!(trash.tasks.is_empty());
+}
+
+#[tokio::test]
+async fn undo_restores_title_then_conflict_on_second_change() {
+    let app = seeded_task().await;
+    app.task_update(
+        &cli_actor(),
+        TaskUpdate {
+            display_id: "TASK-1".into(),
+            title: Some("B".into()),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    app.undo(&cli_actor()).await.unwrap();
+    assert_eq!(
+        app.task_show("TASK-1").await.unwrap().title,
+        "Fix login error"
+    );
+}
+
+#[tokio::test]
+async fn second_undo_is_conflict() {
+    let app = seeded_task().await;
+    app.task_update(
+        &cli_actor(),
+        TaskUpdate {
+            display_id: "TASK-1".into(),
+            title: Some("B".into()),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    app.undo(&cli_actor()).await.unwrap();
+    let err = app.undo(&cli_actor()).await.unwrap_err();
+    assert_eq!(err.code(), "undo_conflict");
+}
+
+#[tokio::test]
+async fn trash_list_includes_deleted_projects_and_tasks() {
+    let app = seeded_task().await;
+    app.task_delete(&cli_actor(), "TASK-1", None).await.unwrap();
+    app.project_delete(&cli_actor(), "renai-sim", None)
+        .await
+        .unwrap();
+    let trash = app.trash_list().await.unwrap();
+    assert_eq!(trash.projects[0].slug, "renai-sim");
+    assert_eq!(trash.tasks[0].display_id, "TASK-1");
+}
+
+#[tokio::test]
+async fn restore_assigns_unique_position_in_column() {
+    let app = seeded_task().await;
+    app.task_create(
+        &cli_actor(),
+        TaskCreate {
+            project_slug: "renai-sim".into(),
+            title: "Second".into(),
+            column: Some(Column::Todo),
+            urgent: false,
+        },
+    )
+    .await
+    .unwrap();
+    app.task_delete(&cli_actor(), "TASK-1", None).await.unwrap();
+    app.task_create(
+        &cli_actor(),
+        TaskCreate {
+            project_slug: "renai-sim".into(),
+            title: "Third".into(),
+            column: Some(Column::Todo),
+            urgent: false,
+        },
+    )
+    .await
+    .unwrap();
+    app.task_restore(&cli_actor(), "TASK-1").await.unwrap();
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert!(ids.contains(&"TASK-1"));
+    assert!(ids.contains(&"TASK-2"));
+    assert!(ids.contains(&"TASK-3"));
+    assert_eq!(listed.len(), 3);
+}
+
+#[tokio::test]
+async fn activity_head_and_sync_see_task_update() {
+    let app = seeded_task().await;
+    let before = app.activity_head().await.unwrap();
+    app.task_update(
+        &cli_actor(),
+        TaskUpdate {
+            display_id: "TASK-1".into(),
+            title: Some("Renamed".into()),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    let head = app.activity_head().await.unwrap();
+    assert_eq!(head, before + 1);
+    let delta = app.sync(before).await.unwrap();
+    assert_eq!(delta.sequence, head);
+    assert!(
+        delta.tasks.iter().any(|task| task.title == "Renamed"),
+        "sync should include the changed task"
+    );
+}
+
+#[tokio::test]
+async fn backup_export_import_round_trip() {
+    let app = seeded_task().await;
+    let dest = app.tmp.path().join("export.sqlite3");
+    app.backup_export(&dest).await.unwrap();
+    app.task_update(
+        &cli_actor(),
+        TaskUpdate {
+            display_id: "TASK-1".into(),
+            title: Some("Changed".into()),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(app.task_show("TASK-1").await.unwrap().title, "Changed");
+    app.backup_import(&dest).await.unwrap();
+    assert_eq!(
+        app.task_show("TASK-1").await.unwrap().title,
+        "Fix login error"
+    );
+    let backups = app.tmp.path().join("backups");
+    let names: Vec<String> = std::fs::read_dir(&backups)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        names
+            .iter()
+            .any(|name| name.starts_with("pre-import-") && name.ends_with(".sqlite3")),
+        "expected pre-import backup, got {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn backup_import_rejects_non_taskboard_db() {
+    let app = seeded_task().await;
+    let junk = app.tmp.path().join("junk.sqlite3");
+    std::fs::write(&junk, b"not a database").unwrap();
+    let err = app.backup_import(&junk).await.unwrap_err();
+    assert_eq!(err.code(), "io_error");
+    assert_eq!(
+        app.task_show("TASK-1").await.unwrap().title,
+        "Fix login error"
+    );
+}
+
+#[tokio::test]
+async fn two_pools_second_writer_sees_busy_or_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    let pool_a = open_db(tmp.path()).await.unwrap();
+    let pool_b = open_db(tmp.path()).await.unwrap();
+    let app_a = App::new(SqliteStore::new(pool_a.clone()), SystemClock);
+    let app_b = App::new(SqliteStore::new(pool_b), SystemClock);
+
+    app_a
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "Renai Sim".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut holder = SqliteStore::new(pool_a);
+    holder.begin().await.unwrap();
+    holder.next_display_n("task").await.unwrap();
+
+    let start = Instant::now();
+    let result = app_b
+        .task_create(
+            &cli_actor(),
+            TaskCreate {
+                project_slug: "renai-sim".into(),
+                title: "Concurrent".into(),
+                column: None,
+                urgent: false,
+            },
+        )
+        .await;
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed <= Duration::from_secs(6),
+        "second writer hung for {elapsed:?}"
+    );
+    match result {
+        Ok(_) => {}
+        Err(err) => assert_eq!(err.code(), "database_busy"),
+    }
+
+    holder.rollback().await.unwrap();
+}

--- a/crates/application/tests/concurrency.rs
+++ b/crates/application/tests/concurrency.rs
@@ -260,6 +260,132 @@ async fn backup_import_rejects_non_taskboard_db() {
         app.task_show("TASK-1").await.unwrap().title,
         "Fix login error"
     );
+    let projects = app.project_list(false).await.unwrap();
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].slug, "renai-sim");
+}
+
+#[tokio::test]
+async fn backup_import_rejects_sqlite_without_projects_without_wiping() {
+    let app = seeded_task().await;
+    let junk = app.tmp.path().join("not-taskboard.sqlite3");
+    let status = std::process::Command::new("sqlite3")
+        .arg(&junk)
+        .arg("CREATE TABLE leftover (id INTEGER);")
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let err = app.backup_import(&junk).await.unwrap_err();
+    assert_eq!(err.code(), "io_error");
+    let projects = app.project_list(false).await.unwrap();
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].slug, "renai-sim");
+    assert_eq!(
+        app.task_show("TASK-1").await.unwrap().title,
+        "Fix login error"
+    );
+}
+
+#[tokio::test]
+async fn backup_import_rejects_wrong_schema_projects_table_without_wiping() {
+    let app = seeded_task().await;
+    let junk = app.tmp.path().join("fake-projects.sqlite3");
+    let status = std::process::Command::new("sqlite3")
+        .arg(&junk)
+        .arg("CREATE TABLE projects (id INTEGER PRIMARY KEY);")
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let err = app.backup_import(&junk).await.unwrap_err();
+    assert_eq!(err.code(), "io_error");
+    let projects = app.project_list(false).await.unwrap();
+    assert_eq!(projects.len(), 1, "import must not delete live projects");
+    assert_eq!(projects[0].slug, "renai-sim");
+    assert_eq!(
+        app.task_show("TASK-1").await.unwrap().title,
+        "Fix login error"
+    );
+}
+
+#[tokio::test]
+async fn undo_task_create_rewrites_positions_so_next_create_does_not_collide() {
+    let app = seeded_task().await;
+    app.task_create(
+        &cli_actor(),
+        TaskCreate {
+            project_slug: "renai-sim".into(),
+            title: "Urgent card".into(),
+            column: Some(Column::Todo),
+            urgent: true,
+        },
+    )
+    .await
+    .unwrap();
+    app.undo(&cli_actor()).await.unwrap();
+    let created = app
+        .task_create(
+            &cli_actor(),
+            TaskCreate {
+                project_slug: "renai-sim".into(),
+                title: "Another".into(),
+                column: Some(Column::Todo),
+                urgent: false,
+            },
+        )
+        .await
+        .expect("creating after undo of task.create must not unique-collide");
+    assert_eq!(created.display_id, "TASK-3");
+    let listed = app.task_list("renai-sim").await.unwrap();
+    let ids: Vec<_> = listed.iter().map(|t| t.display_id.as_str()).collect();
+    assert_eq!(ids, ["TASK-1", "TASK-3"]);
+}
+
+#[tokio::test]
+async fn undo_of_title_update_increments_revision_past_pre_undo_current() {
+    let app = seeded_task().await;
+    app.task_update(
+        &cli_actor(),
+        TaskUpdate {
+            display_id: "TASK-1".into(),
+            title: Some("B".into()),
+            revision: None,
+        },
+    )
+    .await
+    .unwrap();
+    let current = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(current.revision, 2);
+    app.undo(&cli_actor()).await.unwrap();
+    let shown = app.task_show("TASK-1").await.unwrap();
+    assert_eq!(shown.title, "Fix login error");
+    assert!(
+        shown.revision > current.revision,
+        "undo must bump revision above pre-undo current {}, got {}",
+        current.revision,
+        shown.revision
+    );
+    assert_ne!(
+        shown.revision, 1,
+        "must not rewind to the original revision"
+    );
+    let undo_activity = shown
+        .recent_activities
+        .iter()
+        .find(|activity| activity.operation == "undo")
+        .expect("undo activity");
+    assert_eq!(undo_activity.previous_revision, Some(current.revision));
+    let updated = app
+        .task_update(
+            &cli_actor(),
+            TaskUpdate {
+                display_id: "TASK-1".into(),
+                title: Some("C".into()),
+                revision: Some(shown.revision),
+            },
+        )
+        .await
+        .expect("client holding the post-undo revision must be able to mutate");
+    assert_eq!(updated.title, "C");
 }
 
 #[tokio::test]
@@ -267,8 +393,8 @@ async fn two_pools_second_writer_sees_busy_or_success() {
     let tmp = tempfile::tempdir().unwrap();
     let pool_a = open_db(tmp.path()).await.unwrap();
     let pool_b = open_db(tmp.path()).await.unwrap();
-    let app_a = App::new(SqliteStore::new(pool_a.clone()), SystemClock);
-    let app_b = App::new(SqliteStore::new(pool_b), SystemClock);
+    let app_a = App::new(SqliteStore::new(pool_a.clone(), tmp.path()), SystemClock);
+    let app_b = App::new(SqliteStore::new(pool_b, tmp.path()), SystemClock);
 
     app_a
         .project_add(
@@ -282,7 +408,7 @@ async fn two_pools_second_writer_sees_busy_or_success() {
         .await
         .unwrap();
 
-    let mut holder = SqliteStore::new(pool_a);
+    let mut holder = SqliteStore::new(pool_a, tmp.path());
     holder.begin().await.unwrap();
     holder.next_display_n("task").await.unwrap();
 

--- a/crates/application/tests/notes_runs.rs
+++ b/crates/application/tests/notes_runs.rs
@@ -16,7 +16,7 @@ struct TestApp {
 impl TestApp {
     async fn task_row(&self, display_id: &str) -> Task {
         let pool = open_db(self._tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool);
+        let mut store = SqliteStore::new(pool, self._tmp.path());
         store
             .get_task_by_display_id(display_id, false)
             .await
@@ -26,13 +26,13 @@ impl TestApp {
 
     async fn latest_activity_for(&self, entity_id: Uuid) -> taskboard_core::Activity {
         let pool = open_db(self._tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool);
+        let mut store = SqliteStore::new(pool, self._tmp.path());
         store.latest_activity_for(entity_id).await.unwrap().unwrap()
     }
 
     async fn get_run(&self, display_id: &str) -> Run {
         let pool = open_db(self._tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool);
+        let mut store = SqliteStore::new(pool, self._tmp.path());
         store
             .get_run_by_display_id(display_id)
             .await
@@ -42,13 +42,13 @@ impl TestApp {
 
     async fn get_link(&self, id: Uuid) -> Option<taskboard_core::Link> {
         let pool = open_db(self._tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool);
+        let mut store = SqliteStore::new(pool, self._tmp.path());
         store.get_link(id).await.unwrap()
     }
 
     async fn soft_delete_task(&self, display_id: &str) {
         let pool = open_db(self._tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool);
+        let mut store = SqliteStore::new(pool, self._tmp.path());
         let task = store
             .get_task_by_display_id(display_id, false)
             .await
@@ -79,7 +79,7 @@ fn cli_actor() -> Actor {
 async fn test_app() -> TestApp {
     let tmp = tempfile::tempdir().unwrap();
     let pool = open_db(tmp.path()).await.unwrap();
-    let store = SqliteStore::new(pool);
+    let store = SqliteStore::new(pool, tmp.path());
     TestApp {
         app: App::new(store, SystemClock),
         _tmp: tmp,

--- a/crates/application/tests/projects.rs
+++ b/crates/application/tests/projects.rs
@@ -14,7 +14,7 @@ struct TestApp {
 impl TestApp {
     async fn activity_head(&self) -> i64 {
         let pool = open_db(self._tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool);
+        let mut store = SqliteStore::new(pool, self._tmp.path());
         store.activity_head().await.unwrap()
     }
 }
@@ -37,7 +37,7 @@ fn cli_actor() -> Actor {
 async fn test_app() -> TestApp {
     let tmp = tempfile::tempdir().unwrap();
     let pool = open_db(tmp.path()).await.unwrap();
-    let store = SqliteStore::new(pool);
+    let store = SqliteStore::new(pool, tmp.path());
     TestApp {
         app: App::new(store, SystemClock),
         _tmp: tmp,

--- a/crates/application/tests/tasks.rs
+++ b/crates/application/tests/tasks.rs
@@ -14,7 +14,7 @@ struct TestApp {
 impl TestApp {
     async fn task_row(&self, display_id: &str) -> Task {
         let pool = open_db(self._tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool);
+        let mut store = SqliteStore::new(pool, self._tmp.path());
         store
             .get_task_by_display_id(display_id, false)
             .await
@@ -41,7 +41,7 @@ fn cli_actor() -> Actor {
 async fn test_app() -> TestApp {
     let tmp = tempfile::tempdir().unwrap();
     let pool = open_db(tmp.path()).await.unwrap();
-    let store = SqliteStore::new(pool);
+    let store = SqliteStore::new(pool, tmp.path());
     TestApp {
         app: App::new(store, SystemClock),
         _tmp: tmp,

--- a/crates/store-sqlite/src/db.rs
+++ b/crates/store-sqlite/src/db.rs
@@ -132,6 +132,9 @@ fn map_io(err: std::io::Error) -> AppError {
 }
 
 pub(crate) fn map_sqlx(err: sqlx::Error) -> AppError {
+    if matches!(err, sqlx::Error::PoolTimedOut) {
+        return AppError::DatabaseBusy;
+    }
     if let sqlx::Error::Database(db_err) = &err {
         let code = db_err.code();
         if matches!(code.as_deref(), Some("5" | "6")) {

--- a/crates/store-sqlite/src/store.rs
+++ b/crates/store-sqlite/src/store.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -23,24 +24,124 @@ macro_rules! run {
         if let Some(conn) = $self.conn.as_mut() {
             $query.$method(&mut **conn).await
         } else {
-            $query.$method(&$self.pool).await
+            $query
+                .$method($self.pool.as_ref().expect("sqlite pool is closed"))
+                .await
         }
     };
 }
 
 pub struct SqliteStore {
-    pool: SqlitePool,
+    pool: Option<SqlitePool>,
     conn: Option<sqlx::pool::PoolConnection<sqlx::Sqlite>>,
+    data_dir: PathBuf,
 }
 
 impl SqliteStore {
     pub fn new(pool: SqlitePool) -> Self {
-        Self { pool, conn: None }
+        Self {
+            pool: Some(pool),
+            conn: None,
+            data_dir: PathBuf::new(),
+        }
     }
-}
 
-fn not_impl(what: &str) -> AppError {
-    AppError::Io(format!("{what} is not implemented"))
+    pub fn with_data_dir(pool: SqlitePool, data_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            pool: Some(pool),
+            conn: None,
+            data_dir: data_dir.into(),
+        }
+    }
+
+    async fn purge_task_row(&mut self, task_id: Uuid) -> Result<(), AppError> {
+        let bytes = uuid_bytes(task_id);
+        let null_links = sqlx::query(
+            "UPDATE activities SET before_json = NULL, after_json = NULL WHERE entity_id IN (SELECT id FROM links WHERE task_id = ?)",
+        )
+        .bind(&bytes);
+        run!(self, null_links, execute).map_err(map_sqlx)?;
+        let null_runs = sqlx::query(
+            "UPDATE activities SET before_json = NULL, after_json = NULL WHERE entity_id IN (SELECT id FROM runs WHERE task_id = ?)",
+        )
+        .bind(&bytes);
+        run!(self, null_runs, execute).map_err(map_sqlx)?;
+        let null_task = sqlx::query(
+            "UPDATE activities SET before_json = NULL, after_json = NULL WHERE entity_id = ?",
+        )
+        .bind(&bytes);
+        run!(self, null_task, execute).map_err(map_sqlx)?;
+        let delete_links = sqlx::query("DELETE FROM links WHERE task_id = ?").bind(&bytes);
+        run!(self, delete_links, execute).map_err(map_sqlx)?;
+        let delete_runs = sqlx::query("DELETE FROM runs WHERE task_id = ?").bind(&bytes);
+        run!(self, delete_runs, execute).map_err(map_sqlx)?;
+        let delete_task = sqlx::query("DELETE FROM tasks WHERE id = ?").bind(&bytes);
+        run!(self, delete_task, execute).map_err(map_sqlx)?;
+        Ok(())
+    }
+
+    async fn purge_project_row(&mut self, project_id: Uuid) -> Result<(), AppError> {
+        let bytes = uuid_bytes(project_id);
+        let null_project = sqlx::query(
+            "UPDATE activities SET before_json = NULL, after_json = NULL WHERE entity_id = ?",
+        )
+        .bind(&bytes);
+        run!(self, null_project, execute).map_err(map_sqlx)?;
+        let delete_project = sqlx::query("DELETE FROM projects WHERE id = ?").bind(&bytes);
+        run!(self, delete_project, execute).map_err(map_sqlx)?;
+        Ok(())
+    }
+
+    async fn import_attached(&mut self, src: &Path) -> Result<(), AppError> {
+        let src_sql = src.to_string_lossy().replace('\'', "''");
+        let attach_sql = format!("ATTACH DATABASE '{src_sql}' AS incoming");
+        let attach = sqlx::query(&attach_sql);
+        run!(self, attach, execute).map_err(map_sqlx)?;
+        let check = sqlx::query_scalar(
+            "SELECT name FROM incoming.sqlite_master WHERE type = 'table' AND name = 'projects'",
+        );
+        let incoming_projects: Result<Option<String>, AppError> =
+            run!(self, check, fetch_optional).map_err(map_sqlx);
+        let name = match incoming_projects {
+            Ok(name) => name,
+            Err(err) => {
+                let detach = sqlx::query("DETACH DATABASE incoming");
+                let _ = run!(self, detach, execute);
+                return Err(err);
+            }
+        };
+        if name.is_none() {
+            let detach = sqlx::query("DETACH DATABASE incoming");
+            let _ = run!(self, detach, execute);
+            return Err(AppError::Io("file is not a Taskboard database".into()));
+        }
+        for sql in [
+            "PRAGMA foreign_keys = OFF",
+            "DELETE FROM links",
+            "DELETE FROM runs",
+            "DELETE FROM activities",
+            "DELETE FROM tasks",
+            "DELETE FROM projects",
+            "DELETE FROM counters",
+            "INSERT INTO counters SELECT * FROM incoming.counters",
+            "INSERT INTO projects SELECT * FROM incoming.projects",
+            "INSERT INTO tasks SELECT * FROM incoming.tasks",
+            "INSERT INTO links SELECT * FROM incoming.links",
+            "INSERT INTO runs SELECT * FROM incoming.runs",
+            "INSERT INTO activities SELECT * FROM incoming.activities",
+            "PRAGMA foreign_keys = ON",
+        ] {
+            let query = sqlx::query(sql);
+            if let Err(err) = run!(self, query, execute).map_err(map_sqlx) {
+                let detach = sqlx::query("DETACH DATABASE incoming");
+                let _ = run!(self, detach, execute);
+                return Err(err);
+            }
+        }
+        let detach = sqlx::query("DETACH DATABASE incoming");
+        run!(self, detach, execute).map_err(map_sqlx)?;
+        Ok(())
+    }
 }
 
 fn fmt_dt(dt: DateTime<Utc>) -> String {
@@ -630,25 +731,123 @@ impl Store for SqliteStore {
 
     async fn purge_expired(
         &mut self,
-        _now: DateTime<Utc>,
-        _retention_days: i64,
+        now: DateTime<Utc>,
+        retention_days: i64,
     ) -> Result<u64, AppError> {
-        Err(not_impl("purge_expired"))
+        let cutoff = now - chrono::Duration::days(retention_days);
+        let cutoff_s = fmt_dt(cutoff);
+        let mut task_ids = Vec::new();
+        let task_query =
+            sqlx::query("SELECT id FROM tasks WHERE deleted_at IS NOT NULL AND deleted_at <= ?")
+                .bind(&cutoff_s);
+        let task_rows = run!(self, task_query, fetch_all).map_err(map_sqlx)?;
+        for row in &task_rows {
+            let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+            task_ids.push(uuid_from_blob(&id)?);
+        }
+
+        let project_query =
+            sqlx::query("SELECT id FROM projects WHERE deleted_at IS NOT NULL AND deleted_at <= ?")
+                .bind(&cutoff_s);
+        let project_rows = run!(self, project_query, fetch_all).map_err(map_sqlx)?;
+        let mut project_ids = Vec::new();
+        for row in &project_rows {
+            let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+            project_ids.push(uuid_from_blob(&id)?);
+        }
+
+        for project_id in &project_ids {
+            let child_query = sqlx::query("SELECT id FROM tasks WHERE project_id = ?")
+                .bind(uuid_bytes(*project_id));
+            let child_rows = run!(self, child_query, fetch_all).map_err(map_sqlx)?;
+            for row in &child_rows {
+                let id: Vec<u8> = row.try_get("id").map_err(map_sqlx)?;
+                let task_id = uuid_from_blob(&id)?;
+                if !task_ids.contains(&task_id) {
+                    task_ids.push(task_id);
+                }
+            }
+        }
+
+        let mut purged = 0u64;
+        for task_id in task_ids {
+            self.purge_task_row(task_id).await?;
+            purged += 1;
+        }
+        for project_id in project_ids {
+            self.purge_project_row(project_id).await?;
+            purged += 1;
+        }
+        Ok(purged)
     }
 
-    async fn backup_to(&mut self, _dest: &Path) -> Result<(), AppError> {
-        Err(not_impl("backup_to"))
+    async fn backup_to(&mut self, dest: &Path) -> Result<(), AppError> {
+        let dest = dest.to_path_buf();
+        if let Some(parent) = dest.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).map_err(|err| AppError::Io(err.to_string()))?;
+            }
+        }
+        if dest.exists() {
+            fs::remove_file(&dest).map_err(|err| AppError::Io(err.to_string()))?;
+        }
+        let checkpoint = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)");
+        run!(self, checkpoint, execute).map_err(map_sqlx)?;
+        let dest_sql = dest.to_string_lossy().replace('\'', "''");
+        let sql = format!("VACUUM INTO '{dest_sql}'");
+        let vacuum = sqlx::query(&sql);
+        run!(self, vacuum, execute).map_err(map_sqlx)?;
+        Ok(())
     }
 
-    async fn replace_from(&mut self, _src: &Path) -> Result<(), AppError> {
-        Err(not_impl("replace_from"))
+    async fn replace_from(&mut self, src: &Path) -> Result<(), AppError> {
+        let src = src.to_path_buf();
+        if self.conn.is_some() {
+            return Err(AppError::Io("cannot import during a transaction".into()));
+        }
+        if self.data_dir.as_os_str().is_empty() {
+            return Err(AppError::Io(
+                "data directory is unknown; cannot import".into(),
+            ));
+        }
+        let backups = self.data_dir.join("backups");
+        fs::create_dir_all(&backups).map_err(|err| AppError::Io(err.to_string()))?;
+        let stamp = Utc::now().format("%Y%m%dT%H%M%SZ");
+        let pre = backups.join(format!("pre-import-{stamp}.sqlite3"));
+        if pre.exists() {
+            fs::remove_file(&pre).map_err(|err| AppError::Io(err.to_string()))?;
+        }
+        let checkpoint = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)");
+        run!(self, checkpoint, execute).map_err(map_sqlx)?;
+        let pre_sql = pre.to_string_lossy().replace('\'', "''");
+        let vacuum_sql = format!("VACUUM INTO '{pre_sql}'");
+        let vacuum = sqlx::query(&vacuum_sql);
+        run!(self, vacuum, execute).map_err(map_sqlx)?;
+
+        let conn = self
+            .pool
+            .as_ref()
+            .ok_or_else(|| AppError::Io("database pool is closed".into()))?
+            .acquire()
+            .await
+            .map_err(map_sqlx)?;
+        self.conn = Some(conn);
+        let result = self.import_attached(&src).await;
+        self.conn.take();
+        result
     }
 
     async fn begin(&mut self) -> Result<(), AppError> {
         if self.conn.is_some() {
             return Err(AppError::Io("transaction already active".into()));
         }
-        let mut conn = self.pool.acquire().await.map_err(map_sqlx)?;
+        let mut conn = self
+            .pool
+            .as_ref()
+            .ok_or_else(|| AppError::Io("database pool is closed".into()))?
+            .acquire()
+            .await
+            .map_err(map_sqlx)?;
         sqlx::query("BEGIN IMMEDIATE")
             .execute(&mut *conn)
             .await

--- a/crates/store-sqlite/src/store.rs
+++ b/crates/store-sqlite/src/store.rs
@@ -1,9 +1,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, SecondsFormat, Utc};
-use sqlx::sqlite::SqliteRow;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteRow};
 use sqlx::{Row, SqlitePool};
 use taskboard_application::{AppError, NewActivity, Store};
 use taskboard_core::{
@@ -38,20 +39,16 @@ pub struct SqliteStore {
 }
 
 impl SqliteStore {
-    pub fn new(pool: SqlitePool) -> Self {
-        Self {
-            pool: Some(pool),
-            conn: None,
-            data_dir: PathBuf::new(),
-        }
-    }
-
-    pub fn with_data_dir(pool: SqlitePool, data_dir: impl Into<PathBuf>) -> Self {
+    pub fn new(pool: SqlitePool, data_dir: impl Into<PathBuf>) -> Self {
         Self {
             pool: Some(pool),
             conn: None,
             data_dir: data_dir.into(),
         }
+    }
+
+    pub fn with_data_dir(pool: SqlitePool, data_dir: impl Into<PathBuf>) -> Self {
+        Self::new(pool, data_dir)
     }
 
     async fn purge_task_row(&mut self, task_id: Uuid) -> Result<(), AppError> {
@@ -91,57 +88,6 @@ impl SqliteStore {
         run!(self, delete_project, execute).map_err(map_sqlx)?;
         Ok(())
     }
-
-    async fn import_attached(&mut self, src: &Path) -> Result<(), AppError> {
-        let src_sql = src.to_string_lossy().replace('\'', "''");
-        let attach_sql = format!("ATTACH DATABASE '{src_sql}' AS incoming");
-        let attach = sqlx::query(&attach_sql);
-        run!(self, attach, execute).map_err(map_sqlx)?;
-        let check = sqlx::query_scalar(
-            "SELECT name FROM incoming.sqlite_master WHERE type = 'table' AND name = 'projects'",
-        );
-        let incoming_projects: Result<Option<String>, AppError> =
-            run!(self, check, fetch_optional).map_err(map_sqlx);
-        let name = match incoming_projects {
-            Ok(name) => name,
-            Err(err) => {
-                let detach = sqlx::query("DETACH DATABASE incoming");
-                let _ = run!(self, detach, execute);
-                return Err(err);
-            }
-        };
-        if name.is_none() {
-            let detach = sqlx::query("DETACH DATABASE incoming");
-            let _ = run!(self, detach, execute);
-            return Err(AppError::Io("file is not a Taskboard database".into()));
-        }
-        for sql in [
-            "PRAGMA foreign_keys = OFF",
-            "DELETE FROM links",
-            "DELETE FROM runs",
-            "DELETE FROM activities",
-            "DELETE FROM tasks",
-            "DELETE FROM projects",
-            "DELETE FROM counters",
-            "INSERT INTO counters SELECT * FROM incoming.counters",
-            "INSERT INTO projects SELECT * FROM incoming.projects",
-            "INSERT INTO tasks SELECT * FROM incoming.tasks",
-            "INSERT INTO links SELECT * FROM incoming.links",
-            "INSERT INTO runs SELECT * FROM incoming.runs",
-            "INSERT INTO activities SELECT * FROM incoming.activities",
-            "PRAGMA foreign_keys = ON",
-        ] {
-            let query = sqlx::query(sql);
-            if let Err(err) = run!(self, query, execute).map_err(map_sqlx) {
-                let detach = sqlx::query("DETACH DATABASE incoming");
-                let _ = run!(self, detach, execute);
-                return Err(err);
-            }
-        }
-        let detach = sqlx::query("DETACH DATABASE incoming");
-        run!(self, detach, execute).map_err(map_sqlx)?;
-        Ok(())
-    }
 }
 
 fn fmt_dt(dt: DateTime<Utc>) -> String {
@@ -160,6 +106,66 @@ fn uuid_from_blob(bytes: &[u8]) -> Result<Uuid, AppError> {
 
 fn uuid_bytes(id: Uuid) -> Vec<u8> {
     id.as_bytes().to_vec()
+}
+
+fn sidecar(live: &Path, suffix: &str) -> PathBuf {
+    let mut name = live.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+fn copy_over_sqlite(live: &Path, src: &Path) -> Result<(), AppError> {
+    let tmp = live.with_file_name(".import-incoming.sqlite3");
+    if tmp.exists() {
+        fs::remove_file(&tmp).map_err(|err| AppError::Io(err.to_string()))?;
+    }
+    fs::copy(src, &tmp).map_err(|err| AppError::Io(err.to_string()))?;
+    fs::rename(&tmp, live).map_err(|err| AppError::Io(err.to_string()))?;
+    let _ = fs::remove_file(sidecar(live, "-wal"));
+    let _ = fs::remove_file(sidecar(live, "-shm"));
+    Ok(())
+}
+
+fn not_taskboard() -> AppError {
+    AppError::Io("file is not a Taskboard database".into())
+}
+
+async fn assert_incoming_is_taskboard(src: PathBuf) -> Result<(), AppError> {
+    let options = SqliteConnectOptions::new()
+        .filename(&src)
+        .create_if_missing(false)
+        .read_only(true);
+    let pool = match SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+    {
+        Ok(pool) => pool,
+        Err(err) => return Err(map_sqlx(err)),
+    };
+    let name: Result<Option<String>, _> = sqlx::query_scalar(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'projects'",
+    )
+    .fetch_optional(&pool)
+    .await;
+    let name = match name {
+        Ok(name) => name,
+        Err(err) => {
+            pool.close().await;
+            return Err(map_sqlx(err));
+        }
+    };
+    if name.is_none() {
+        pool.close().await;
+        return Err(not_taskboard());
+    }
+    let sql = format!("SELECT {PROJECT_COLUMNS} FROM projects LIMIT 0");
+    let probe = sqlx::query(&sql).fetch_optional(&pool).await;
+    pool.close().await;
+    match probe {
+        Ok(_) => Ok(()),
+        Err(_) => Err(not_taskboard()),
+    }
 }
 
 fn map_constraint(err: sqlx::Error, slug: &str) -> AppError {
@@ -800,41 +806,69 @@ impl Store for SqliteStore {
         Ok(())
     }
 
-    async fn replace_from(&mut self, src: &Path) -> Result<(), AppError> {
+    async fn validate_import(&mut self, src: &Path) -> Result<(), AppError> {
         let src = src.to_path_buf();
-        if self.conn.is_some() {
-            return Err(AppError::Io("cannot import during a transaction".into()));
-        }
+        assert_incoming_is_taskboard(src).await
+    }
+
+    fn pre_import_path(&self) -> Result<PathBuf, AppError> {
         if self.data_dir.as_os_str().is_empty() {
             return Err(AppError::Io(
                 "data directory is unknown; cannot import".into(),
             ));
         }
-        let backups = self.data_dir.join("backups");
-        fs::create_dir_all(&backups).map_err(|err| AppError::Io(err.to_string()))?;
         let stamp = Utc::now().format("%Y%m%dT%H%M%SZ");
-        let pre = backups.join(format!("pre-import-{stamp}.sqlite3"));
-        if pre.exists() {
-            fs::remove_file(&pre).map_err(|err| AppError::Io(err.to_string()))?;
-        }
-        let checkpoint = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)");
-        run!(self, checkpoint, execute).map_err(map_sqlx)?;
-        let pre_sql = pre.to_string_lossy().replace('\'', "''");
-        let vacuum_sql = format!("VACUUM INTO '{pre_sql}'");
-        let vacuum = sqlx::query(&vacuum_sql);
-        run!(self, vacuum, execute).map_err(map_sqlx)?;
+        Ok(self
+            .data_dir
+            .join("backups")
+            .join(format!("pre-import-{stamp}.sqlite3")))
+    }
 
-        let conn = self
-            .pool
-            .as_ref()
-            .ok_or_else(|| AppError::Io("database pool is closed".into()))?
-            .acquire()
+    async fn close_pool(&mut self) -> Result<(), AppError> {
+        if self.conn.is_some() {
+            return Err(AppError::Io("cannot import during a transaction".into()));
+        }
+        if let Some(pool) = self.pool.take() {
+            pool.close().await;
+        }
+        Ok(())
+    }
+
+    async fn reopen_pool(&mut self) -> Result<(), AppError> {
+        let data_dir = self.data_dir.clone();
+        if data_dir.as_os_str().is_empty() {
+            return Err(AppError::Io(
+                "data directory is unknown; cannot import".into(),
+            ));
+        }
+        let db_path = data_dir.join("taskboard.sqlite3");
+        let cfg = crate::load_config(&data_dir);
+        let options = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .foreign_keys(true)
+            .busy_timeout(Duration::from_millis(cfg.busy_timeout_ms));
+        let pool = SqlitePoolOptions::new()
+            .connect_with(options)
             .await
             .map_err(map_sqlx)?;
-        self.conn = Some(conn);
-        let result = self.import_attached(&src).await;
-        self.conn.take();
-        result
+        self.pool = Some(pool);
+        Ok(())
+    }
+
+    async fn replace_from(&mut self, src: &Path) -> Result<(), AppError> {
+        let src = src.to_path_buf();
+        if self.conn.is_some() {
+            return Err(AppError::Io("cannot import during a transaction".into()));
+        }
+        let data_dir = self.data_dir.clone();
+        if data_dir.as_os_str().is_empty() {
+            return Err(AppError::Io(
+                "data directory is unknown; cannot import".into(),
+            ));
+        }
+        copy_over_sqlite(&data_dir.join("taskboard.sqlite3"), &src)
     }
 
     async fn begin(&mut self) -> Result<(), AppError> {
@@ -893,7 +927,7 @@ mod tests {
     async fn stores_uuid_as_blob16_and_timestamps_with_z() {
         let tmp = tempfile::tempdir().unwrap();
         let pool = crate::open_db(tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool.clone());
+        let mut store = SqliteStore::new(pool.clone(), tmp.path());
         let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
         let project = Project {
             id: Uuid::now_v7(),
@@ -932,7 +966,7 @@ mod tests {
     async fn link_and_run_insert_update_get_delete() {
         let tmp = tempfile::tempdir().unwrap();
         let pool = crate::open_db(tmp.path()).await.unwrap();
-        let mut store = SqliteStore::new(pool.clone());
+        let mut store = SqliteStore::new(pool.clone(), tmp.path());
         let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
         let project = Project {
             id: Uuid::now_v7(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #12

Plan 1 Task 10: optimistic revisions, trash/restore/purge, compensating undo, activity sync, and SQLite backup export/import. Import closes the pool, replaces the database file, and reopens. Undo of a title update increments revision; undo of task create rewrites live positions.

Verify: `cargo test -p taskboard-application -- --test-threads=1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

