### PR TITLE
feat: add taskboard CLI with json and human output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +158,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
@@ -302,6 +338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +354,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "dotenvy"
@@ -376,6 +424,15 @@ name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "flume"
@@ -762,6 +819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +980,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1080,35 @@ checksum = "737970939a87c6fa31e7acad13307bccbb017a073b695b6089a2c484f929e20e"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsa"
@@ -1458,10 +1580,18 @@ dependencies = [
 name = "taskboard-cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
+ "chrono",
  "clap",
+ "predicates",
+ "serde",
  "serde_json",
  "taskboard-application",
+ "taskboard-core",
  "taskboard-store-sqlite",
+ "tempfile",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1505,6 +1635,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1761,6 +1897,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,8 +4,23 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[[bin]]
+name = "taskboard"
+path = "src/main.rs"
+
 [dependencies]
-taskboard-application = { path = "../application" }
-taskboard-store-sqlite = { path = "../store-sqlite" }
+chrono.workspace = true
 clap.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+taskboard-application = { path = "../application" }
+taskboard-core = { path = "../core" }
+taskboard-store-sqlite = { path = "../store-sqlite" }
+tokio.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+assert_cmd = "=2.0.16"
+predicates = "=3.1.3"
+serde_json.workspace = true
+tempfile = "=3.19.1"

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1,0 +1,334 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::{Args, Parser, Subcommand};
+use taskboard_application::Actor;
+use taskboard_core::{ActorKind, Column};
+use uuid::Uuid;
+
+#[derive(Debug, Parser)]
+#[command(name = "taskboard", version, about = "Local Taskboard CLI")]
+pub struct Cli {
+    /// Print snake_case JSON instead of human text.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Data directory (overrides TASKBOARD_DATA_DIR).
+    #[arg(long, global = true, value_name = "PATH")]
+    pub data_dir: Option<PathBuf>,
+
+    /// Actor label recorded in activity (overrides TASKBOARD_ACTOR).
+    #[arg(long = "actor", global = true, value_name = "LABEL")]
+    pub actor_label: Option<String>,
+
+    /// Expected revision for mutation commands.
+    #[arg(long, global = true, value_name = "N")]
+    pub revision: Option<i64>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+impl Cli {
+    pub fn actor(&self) -> Actor {
+        let label = self
+            .actor_label
+            .clone()
+            .or_else(|| {
+                std::env::var("TASKBOARD_ACTOR")
+                    .ok()
+                    .filter(|value| !value.is_empty())
+            })
+            .unwrap_or_else(|| "local-cli".to_string());
+        Actor {
+            kind: ActorKind::Cli,
+            label,
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Project commands
+    #[command(subcommand)]
+    Project(ProjectCommand),
+    /// Replace a project note
+    #[command(name = "project-note", subcommand)]
+    ProjectNote(ProjectNoteCommand),
+    /// Task commands
+    #[command(subcommand)]
+    Task(TaskCommand),
+    /// Task note commands
+    #[command(subcommand)]
+    Note(NoteCommand),
+    /// Task link commands
+    #[command(subcommand)]
+    Link(LinkCommand),
+    /// Agent run commands
+    #[command(subcommand)]
+    Run(RunCommand),
+    /// Soft-deleted entities
+    #[command(subcommand)]
+    Trash(TrashCommand),
+    /// Undo the latest undoable activity
+    Undo,
+    /// Database backup
+    #[command(subcommand)]
+    Backup(BackupCommand),
+    /// Start the local HTTP UI (not available in this build)
+    Serve(ServeArgs),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ProjectCommand {
+    /// Create a project
+    Add {
+        #[arg(long)]
+        name: String,
+        #[arg(long = "path")]
+        repo_path: Option<String>,
+        #[arg(long)]
+        slug: Option<String>,
+    },
+    /// List live projects
+    List {
+        /// Include archived projects
+        #[arg(long)]
+        archived: bool,
+        /// Include archived projects
+        #[arg(long)]
+        all: bool,
+    },
+    /// Show one project
+    Show { slug: String },
+    /// Update a project
+    Update {
+        slug: String,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long = "path")]
+        repo_path: Option<String>,
+        #[arg(long = "slug")]
+        new_slug: Option<String>,
+    },
+    /// Archive a project
+    Archive { slug: String },
+    /// Unarchive a project
+    Unarchive { slug: String },
+    /// Set live project order
+    Reorder {
+        #[arg(required = true, num_args = 1..)]
+        slugs: Vec<String>,
+    },
+    /// Soft-delete a project
+    Delete { slug: String },
+    /// Restore a deleted project
+    Restore { slug: String },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ProjectNoteCommand {
+    /// Set the project note from text or a file
+    #[command(group(
+        clap::ArgGroup::new("body")
+            .required(true)
+            .args(["text", "file"])
+    ))]
+    Set {
+        slug: String,
+        #[arg(long)]
+        text: Option<String>,
+        #[arg(long)]
+        file: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TaskCommand {
+    /// Create a task
+    Create {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        title: String,
+        #[arg(long, value_parser = parse_column)]
+        column: Option<Column>,
+        #[arg(long)]
+        urgent: bool,
+    },
+    /// List tasks in a project
+    List {
+        #[arg(long)]
+        project: String,
+        #[arg(long, value_parser = parse_column)]
+        column: Option<Column>,
+    },
+    /// Show one task
+    Show { display_id: String },
+    /// Update a task title
+    Update {
+        display_id: String,
+        #[arg(long)]
+        title: Option<String>,
+    },
+    /// Move a task to a column
+    Move {
+        display_id: String,
+        #[arg(value_parser = parse_column)]
+        column: Column,
+    },
+    /// Reorder a task in its column
+    #[command(group(
+        clap::ArgGroup::new("place")
+            .required(true)
+            .args(["before", "end"])
+    ))]
+    Prioritize {
+        display_id: String,
+        #[arg(long)]
+        before: Option<String>,
+        #[arg(long)]
+        end: bool,
+    },
+    /// Set or clear the urgent flag
+    Urgent { display_id: String, state: OnOff },
+    /// Soft-delete a task
+    Delete { display_id: String },
+    /// Restore a deleted task
+    Restore { display_id: String },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum NoteCommand {
+    /// Append a paragraph to the task note
+    #[command(group(
+        clap::ArgGroup::new("body")
+            .required(true)
+            .args(["text", "file"])
+    ))]
+    Add {
+        display_id: String,
+        #[arg(long)]
+        text: Option<String>,
+        #[arg(long)]
+        file: Option<PathBuf>,
+    },
+    /// Replace the task note
+    #[command(group(
+        clap::ArgGroup::new("body")
+            .required(true)
+            .args(["text", "file"])
+    ))]
+    Set {
+        display_id: String,
+        #[arg(long)]
+        text: Option<String>,
+        #[arg(long)]
+        file: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LinkCommand {
+    /// Add a URL or path link
+    #[command(group(
+        clap::ArgGroup::new("target")
+            .required(true)
+            .args(["url", "path"])
+    ))]
+    Add {
+        display_id: String,
+        #[arg(long)]
+        url: Option<String>,
+        #[arg(long)]
+        path: Option<String>,
+    },
+    /// Remove a link by UUID
+    Remove { link_id: Uuid },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RunCommand {
+    /// Start a run on a task
+    Start {
+        display_id: String,
+        #[arg(long)]
+        agent: String,
+        #[arg(long = "session")]
+        session_id: Option<String>,
+    },
+    /// Update a running or waiting run
+    Update {
+        run_id: String,
+        #[arg(long)]
+        message: Option<String>,
+    },
+    /// Mark a run as waiting
+    Wait {
+        run_id: String,
+        #[arg(long)]
+        reason: String,
+    },
+    /// Mark a run as failed
+    Fail {
+        run_id: String,
+        #[arg(long)]
+        summary: String,
+    },
+    /// Mark a run as completed
+    Finish {
+        run_id: String,
+        #[arg(long)]
+        summary: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TrashCommand {
+    /// List deleted projects and tasks
+    List,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum BackupCommand {
+    /// Export a consistent copy of the database
+    Export { file: PathBuf },
+    /// Replace the database from a backup file
+    Import { file: PathBuf },
+}
+
+#[derive(Debug, Args)]
+pub struct ServeArgs {
+    #[arg(long)]
+    pub port: Option<u16>,
+    #[arg(long)]
+    pub open: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum OnOff {
+    On,
+    Off,
+}
+
+impl OnOff {
+    pub fn as_bool(self) -> bool {
+        matches!(self, OnOff::On)
+    }
+}
+
+impl FromStr for OnOff {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "on" => Ok(OnOff::On),
+            "off" => Ok(OnOff::Off),
+            other => Err(format!("expected on or off, got {other}")),
+        }
+    }
+}
+
+fn parse_column(s: &str) -> Result<Column, String> {
+    s.parse::<Column>().map_err(|err| err.to_string())
+}

--- a/crates/cli/src/data_dir.rs
+++ b/crates/cli/src/data_dir.rs
@@ -1,0 +1,11 @@
+use std::path::{Path, PathBuf};
+
+use taskboard_store_sqlite::resolve_data_dir;
+
+/// `--data-dir`, then `TASKBOARD_DATA_DIR`, then the platform default.
+pub fn resolve(cli_override: Option<&Path>) -> PathBuf {
+    resolve_data_dir(
+        cli_override,
+        std::env::var_os("TASKBOARD_DATA_DIR").as_deref(),
+    )
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,1 +1,587 @@
-fn main() {}
+mod args;
+mod data_dir;
+mod output;
+
+use std::path::PathBuf;
+
+use chrono::Utc;
+use clap::Parser;
+use taskboard_application::{
+    Actor, App, AppError, LinkAdd, ProjectAdd, ProjectUpdate, RunFail, RunFinish, RunStart,
+    RunUpdate, RunWait, SystemClock, TaskCreate, TaskUpdate,
+};
+use taskboard_core::LinkKind;
+use taskboard_store_sqlite::{open_db, SqliteStore};
+
+use args::{
+    BackupCommand, Cli, Command, LinkCommand, NoteCommand, ProjectCommand, ProjectNoteCommand,
+    RunCommand, TaskCommand, TrashCommand,
+};
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    if let Err(code) = run(cli).await {
+        std::process::exit(code);
+    }
+}
+
+async fn run(cli: Cli) -> Result<(), i32> {
+    if matches!(cli.command, Command::Serve(_)) {
+        eprintln!("error: tb serve is not available in this build");
+        return Err(1);
+    }
+
+    let json = cli.json;
+    let data_dir = data_dir::resolve(cli.data_dir.as_deref());
+    let pool = open_db(&data_dir)
+        .await
+        .map_err(|err| output::print_error(&err, json))?;
+    let store = SqliteStore::new(pool, &data_dir);
+    let app = App::new(store, SystemClock);
+    app.purge_expired_trash(Utc::now())
+        .await
+        .map_err(|err| output::print_error(&err, json))?;
+    let actor = cli.actor();
+    dispatch(&app, &actor, cli).await
+}
+
+async fn dispatch(app: &App, actor: &Actor, cli: Cli) -> Result<(), i32> {
+    let json = cli.json;
+    let revision = cli.revision;
+    match cli.command {
+        Command::Project(cmd) => project_cmd(app, actor, json, revision, cmd).await,
+        Command::ProjectNote(cmd) => project_note_cmd(app, actor, json, revision, cmd).await,
+        Command::Task(cmd) => task_cmd(app, actor, json, revision, cmd).await,
+        Command::Note(cmd) => note_cmd(app, actor, json, revision, cmd).await,
+        Command::Link(cmd) => link_cmd(app, actor, json, revision, cmd).await,
+        Command::Run(cmd) => run_cmd(app, actor, json, revision, cmd).await,
+        Command::Trash(TrashCommand::List) => {
+            let trash = app
+                .trash_list()
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_trash(json, &trash.projects, &trash.tasks, || {
+                println!("PROJECTS");
+                for project in &trash.projects {
+                    println!("{}  {}", project.slug, project.name);
+                }
+                println!("TASKS");
+                for task in &trash.tasks {
+                    println!("{}  {}", task.display_id, task.title);
+                }
+            });
+            Ok(())
+        }
+        Command::Undo => {
+            let result = app
+                .undo(actor)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            let revision = result
+                .entity
+                .get("revision")
+                .and_then(|value| value.as_i64())
+                .unwrap_or(0);
+            let human = output::undo_human(result.entity_type, &result.entity);
+            output::print_entity(json, &result.entity, revision, || println!("{human}"));
+            Ok(())
+        }
+        Command::Backup(cmd) => backup_cmd(app, json, cmd).await,
+        Command::Serve(_) => unreachable!("serve is handled before opening the database"),
+    }
+}
+
+async fn project_cmd(
+    app: &App,
+    actor: &Actor,
+    json: bool,
+    revision: Option<i64>,
+    cmd: ProjectCommand,
+) -> Result<(), i32> {
+    match cmd {
+        ProjectCommand::Add {
+            name,
+            repo_path,
+            slug,
+        } => {
+            let project = app
+                .project_add(
+                    actor,
+                    ProjectAdd {
+                        name,
+                        repo_path,
+                        slug,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &project, project.revision, || {
+                output::created_project(&project);
+            });
+        }
+        ProjectCommand::List { archived, all } => {
+            let projects = app
+                .project_list(archived || all)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entities(json, &projects, || {
+                for project in &projects {
+                    if project.archived {
+                        println!("{}  {}  [archived]", project.slug, project.name);
+                    } else {
+                        println!("{}  {}", project.slug, project.name);
+                    }
+                }
+            });
+        }
+        ProjectCommand::Show { slug } => {
+            let project = app
+                .project_show(&slug)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &project, project.revision, || {
+                println!("{}  {}", project.slug, project.name);
+            });
+        }
+        ProjectCommand::Update {
+            slug,
+            name,
+            repo_path,
+            new_slug,
+        } => {
+            let project = app
+                .project_update(
+                    actor,
+                    ProjectUpdate {
+                        slug,
+                        name,
+                        repo_path,
+                        new_slug,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &project, project.revision, || {
+                println!("Updated project  {}  {}", project.slug, project.name);
+            });
+        }
+        ProjectCommand::Archive { slug } => {
+            let project = app
+                .project_archive(actor, &slug, true, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &project, project.revision, || {
+                println!("Archived project  {}", project.slug);
+            });
+        }
+        ProjectCommand::Unarchive { slug } => {
+            let project = app
+                .project_archive(actor, &slug, false, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &project, project.revision, || {
+                println!("Unarchived project  {}", project.slug);
+            });
+        }
+        ProjectCommand::Reorder { slugs } => {
+            let projects = app
+                .project_reorder(actor, &slugs)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entities(json, &projects, || {
+                let joined = slugs.join("  ");
+                println!("Reordered projects  {joined}");
+            });
+        }
+        ProjectCommand::Delete { slug } => {
+            let project = app
+                .project_delete(actor, &slug, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &project, project.revision, || {
+                println!("Deleted project  {}", project.slug);
+            });
+        }
+        ProjectCommand::Restore { slug } => {
+            let project = app
+                .project_restore(actor, &slug)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &project, project.revision, || {
+                println!("Restored project  {}", project.slug);
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn project_note_cmd(
+    app: &App,
+    actor: &Actor,
+    json: bool,
+    revision: Option<i64>,
+    cmd: ProjectNoteCommand,
+) -> Result<(), i32> {
+    let ProjectNoteCommand::Set { slug, text, file } = cmd;
+    let markdown = load_body(text, file).map_err(|err| output::print_error(&err, json))?;
+    let project = app
+        .project_note_set(actor, &slug, markdown, revision)
+        .await
+        .map_err(|err| output::print_error(&err, json))?;
+    output::print_entity(json, &project, project.revision, || {
+        println!("Updated project note  {}", project.slug);
+    });
+    Ok(())
+}
+
+async fn task_cmd(
+    app: &App,
+    actor: &Actor,
+    json: bool,
+    revision: Option<i64>,
+    cmd: TaskCommand,
+) -> Result<(), i32> {
+    match cmd {
+        TaskCommand::Create {
+            project,
+            title,
+            column,
+            urgent,
+        } => {
+            let task = app
+                .task_create(
+                    actor,
+                    TaskCreate {
+                        project_slug: project,
+                        title,
+                        column,
+                        urgent,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                output::created_task(&task);
+            });
+        }
+        TaskCommand::List { project, column } => {
+            let mut tasks = app
+                .task_list(&project)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            if let Some(column) = column {
+                tasks.retain(|task| task.column == column);
+            }
+            output::print_entities(json, &tasks, || output::print_task_list(&tasks));
+        }
+        TaskCommand::Show { display_id } => {
+            let task = app
+                .task_show(&display_id)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!(
+                    "{}  {}  [{}]",
+                    task.display_id,
+                    task.title,
+                    output::column_label(task.column)
+                );
+            });
+        }
+        TaskCommand::Update { display_id, title } => {
+            let task = app
+                .task_update(
+                    actor,
+                    TaskUpdate {
+                        display_id,
+                        title,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Updated {}  {}", task.display_id, task.title);
+            });
+        }
+        TaskCommand::Move { display_id, column } => {
+            let task = app
+                .task_move(actor, &display_id, column, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!(
+                    "Moved {}  [{}]",
+                    task.display_id,
+                    output::column_label(task.column)
+                );
+            });
+        }
+        TaskCommand::Prioritize {
+            display_id,
+            before,
+            end: _,
+        } => {
+            let task = app
+                .task_reorder(actor, &display_id, before.as_deref(), revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Prioritized {}", task.display_id);
+            });
+        }
+        TaskCommand::Urgent { display_id, state } => {
+            let task = app
+                .task_urgent(actor, &display_id, state.as_bool(), revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!(
+                    "Urgent {}  {}",
+                    task.display_id,
+                    if task.urgent { "on" } else { "off" }
+                );
+            });
+        }
+        TaskCommand::Delete { display_id } => {
+            let task = app
+                .task_delete(actor, &display_id, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Deleted {}", task.display_id);
+            });
+        }
+        TaskCommand::Restore { display_id } => {
+            let task = app
+                .task_restore(actor, &display_id)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Restored {}", task.display_id);
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn note_cmd(
+    app: &App,
+    actor: &Actor,
+    json: bool,
+    revision: Option<i64>,
+    cmd: NoteCommand,
+) -> Result<(), i32> {
+    match cmd {
+        NoteCommand::Add {
+            display_id,
+            text,
+            file,
+        } => {
+            let paragraph = load_body(text, file).map_err(|err| output::print_error(&err, json))?;
+            let task = app
+                .task_note_add(actor, &display_id, &paragraph, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Added note to {}", task.display_id);
+            });
+        }
+        NoteCommand::Set {
+            display_id,
+            text,
+            file,
+        } => {
+            let markdown = load_body(text, file).map_err(|err| output::print_error(&err, json))?;
+            let task = app
+                .task_note_set(actor, &display_id, markdown, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Set note on {}", task.display_id);
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn link_cmd(
+    app: &App,
+    actor: &Actor,
+    json: bool,
+    revision: Option<i64>,
+    cmd: LinkCommand,
+) -> Result<(), i32> {
+    match cmd {
+        LinkCommand::Add {
+            display_id,
+            url,
+            path,
+        } => {
+            let (kind, value) = if let Some(url) = url {
+                (LinkKind::Url, url)
+            } else {
+                (LinkKind::Path, path.expect("clap group requires --path"))
+            };
+            let task = app
+                .link_add(
+                    actor,
+                    LinkAdd {
+                        task_display_id: display_id,
+                        kind,
+                        value,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Added link to {}", task.display_id);
+            });
+        }
+        LinkCommand::Remove { link_id } => {
+            let task = app
+                .link_remove(actor, link_id, revision)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &task, task.revision, || {
+                println!("Removed link {}", link_id);
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn run_cmd(
+    app: &App,
+    actor: &Actor,
+    json: bool,
+    revision: Option<i64>,
+    cmd: RunCommand,
+) -> Result<(), i32> {
+    match cmd {
+        RunCommand::Start {
+            display_id,
+            agent,
+            session_id,
+        } => {
+            let run = app
+                .run_start(
+                    actor,
+                    RunStart {
+                        task_display_id: display_id,
+                        agent,
+                        session_id,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &run, run.revision, || {
+                println!(
+                    "Started {}  {}  [{}]",
+                    run.display_id,
+                    run.agent,
+                    run.status.as_str()
+                );
+            });
+        }
+        RunCommand::Update { run_id, message } => {
+            let run = app
+                .run_update(
+                    actor,
+                    RunUpdate {
+                        run_display_id: run_id,
+                        message,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &run, run.revision, || {
+                println!("Updated {}", run.display_id);
+            });
+        }
+        RunCommand::Wait { run_id, reason } => {
+            let run = app
+                .run_wait(
+                    actor,
+                    RunWait {
+                        run_display_id: run_id,
+                        reason,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &run, run.revision, || {
+                println!("Waiting {}", run.display_id);
+            });
+        }
+        RunCommand::Fail { run_id, summary } => {
+            let run = app
+                .run_fail(
+                    actor,
+                    RunFail {
+                        run_display_id: run_id,
+                        summary,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &run, run.revision, || {
+                println!("Failed {}", run.display_id);
+            });
+        }
+        RunCommand::Finish { run_id, summary } => {
+            let run = app
+                .run_finish(
+                    actor,
+                    RunFinish {
+                        run_display_id: run_id,
+                        summary,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_entity(json, &run, run.revision, || {
+                println!("Finished {}", run.display_id);
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn backup_cmd(app: &App, json: bool, cmd: BackupCommand) -> Result<(), i32> {
+    match cmd {
+        BackupCommand::Export { file } => {
+            app.backup_export(&file)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_ok_path(json, &file, || {
+                println!("Exported backup to  {}", file.display());
+            });
+        }
+        BackupCommand::Import { file } => {
+            app.backup_import(&file)
+                .await
+                .map_err(|err| output::print_error(&err, json))?;
+            output::print_ok(json, || println!("Imported backup"));
+        }
+    }
+    Ok(())
+}
+
+fn load_body(text: Option<String>, file: Option<PathBuf>) -> Result<String, AppError> {
+    if let Some(text) = text {
+        return Ok(text);
+    }
+    let path = file.ok_or_else(|| AppError::Validation {
+        field: "text".into(),
+        message: "either --text or --file is required".into(),
+    })?;
+    std::fs::read_to_string(&path).map_err(|err| AppError::Io(err.to_string()))
+}

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -1,0 +1,175 @@
+use std::path::Path;
+
+use serde::Serialize;
+use taskboard_application::AppError;
+use taskboard_core::{CardDisplayStatus, Column, EntityType, Project, TaskDetail, TaskSummary};
+
+pub fn print_error(err: &AppError, json: bool) -> i32 {
+    if json {
+        println!("{}", error_value(err));
+    } else {
+        eprintln!("error: {err}");
+    }
+    match err {
+        AppError::DatabaseBusy => 2,
+        _ => 1,
+    }
+}
+
+pub fn print_entity<T: Serialize>(json: bool, entity: &T, revision: i64, human: impl FnOnce()) {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "entity": entity,
+                "revision": revision,
+            })
+        );
+    } else {
+        human();
+    }
+}
+
+pub fn print_entities<T: Serialize>(json: bool, entities: &[T], human: impl FnOnce()) {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "entities": entities,
+            })
+        );
+    } else {
+        human();
+    }
+}
+
+pub fn print_ok(json: bool, human: impl FnOnce()) {
+    if json {
+        println!("{}", serde_json::json!({ "ok": true }));
+    } else {
+        human();
+    }
+}
+
+pub fn print_ok_path(json: bool, path: &Path, human: impl FnOnce()) {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "path": path.to_string_lossy(),
+            })
+        );
+    } else {
+        human();
+    }
+}
+
+pub fn print_trash(json: bool, projects: &[Project], tasks: &[TaskSummary], human: impl FnOnce()) {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "entity": {
+                    "projects": projects,
+                    "tasks": tasks,
+                },
+            })
+        );
+    } else {
+        human();
+    }
+}
+
+pub fn created_project(project: &Project) {
+    println!("Created project  {}  {}", project.slug, project.name);
+}
+
+pub fn created_task(task: &TaskDetail) {
+    println!(
+        "Created {}  {}  [{}]",
+        task.display_id,
+        task.title,
+        task.column.as_str()
+    );
+}
+
+pub fn print_task_list(tasks: &[TaskSummary]) {
+    println!("ID  COLUMN  URGENT  RUN  TITLE");
+    for task in tasks {
+        println!(
+            "{}  {}  {}  {}  {}",
+            task.display_id,
+            task.column.as_str(),
+            if task.urgent { "U" } else { "-" },
+            run_badge(task.display_status),
+            task.title
+        );
+    }
+}
+
+pub fn run_badge(status: CardDisplayStatus) -> &'static str {
+    match status {
+        CardDisplayStatus::Idle => "idle",
+        CardDisplayStatus::Running => "running",
+        CardDisplayStatus::Waiting => "waiting",
+        CardDisplayStatus::Failed => "failed",
+        CardDisplayStatus::Completed => "completed",
+    }
+}
+
+pub fn column_label(column: Column) -> &'static str {
+    column.as_str()
+}
+
+pub fn undo_human(entity_type: EntityType, entity: &serde_json::Value) -> String {
+    match entity_type {
+        EntityType::Project => format!(
+            "Undid project  {}",
+            entity
+                .get("slug")
+                .and_then(|v| v.as_str())
+                .unwrap_or("project")
+        ),
+        EntityType::Task => format!(
+            "Undid task  {}",
+            entity
+                .get("display_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("task")
+        ),
+        EntityType::Run => format!(
+            "Undid run  {}",
+            entity
+                .get("display_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("run")
+        ),
+        EntityType::Link => format!(
+            "Undid link  {}",
+            entity.get("id").and_then(|v| v.as_str()).unwrap_or("link")
+        ),
+    }
+}
+
+fn error_value(err: &AppError) -> serde_json::Value {
+    let (field, current) = match err {
+        AppError::Validation { field, .. } => (Some(field.clone()), None),
+        AppError::RevisionConflict { current } | AppError::UndoConflict { current } => {
+            (None, Some(current.clone()))
+        }
+        _ => (None, None),
+    };
+    serde_json::json!({
+        "ok": false,
+        "error": {
+            "code": err.code(),
+            "message": err.to_string(),
+            "field": field,
+            "current": current,
+        }
+    })
+}

--- a/crates/cli/tests/cli_json.rs
+++ b/crates/cli/tests/cli_json.rs
@@ -1,0 +1,232 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn tb() -> (Command, TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    (tb_in(&dir), dir)
+}
+
+fn tb_in(dir: &TempDir) -> Command {
+    let mut c = Command::cargo_bin("taskboard").unwrap();
+    c.env("TASKBOARD_DATA_DIR", dir.path());
+    c.env("HTTP_PROXY", "");
+    c.env("HTTPS_PROXY", "");
+    c.env("http_proxy", "");
+    c.env("https_proxy", "");
+    c
+}
+
+#[test]
+fn project_add_json() {
+    let (mut cmd, _dir) = tb();
+    let out = cmd
+        .args(["project", "add", "--name", "Renai Sim", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["entity"]["slug"], "renai-sim");
+    assert_eq!(v["revision"], 1);
+}
+
+#[test]
+fn failed_mutation_is_not_ok_true() {
+    let (mut cmd, _dir) = tb();
+    let assert = cmd
+        .args(["task", "show", "TASK-999", "--json"])
+        .assert()
+        .failure()
+        .code(1);
+    let stdout = &assert.get_output().stdout;
+    let text = String::from_utf8_lossy(stdout);
+    assert!(
+        !text.contains("\"ok\":true") && !text.contains("\"ok\": true"),
+        "failed show must not print ok:true on stdout, got: {text}"
+    );
+    let v: serde_json::Value = serde_json::from_slice(stdout).unwrap();
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["error"]["code"], "not_found");
+}
+
+#[test]
+fn serve_is_unavailable() {
+    let (mut cmd, _dir) = tb();
+    cmd.args(["serve"])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "error: tb serve is not available in this build",
+        ));
+}
+
+#[test]
+fn project_add_human() {
+    let (mut cmd, _dir) = tb();
+    cmd.args(["project", "add", "--name", "Renai Sim"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Created project  renai-sim  Renai Sim",
+        ));
+}
+
+#[test]
+fn task_create_human() {
+    let dir = tempfile::tempdir().unwrap();
+    tb_in(&dir)
+        .args(["project", "add", "--name", "Renai Sim"])
+        .assert()
+        .success();
+    tb_in(&dir)
+        .args([
+            "task",
+            "create",
+            "--project",
+            "renai-sim",
+            "--title",
+            "Fix login error",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Created TASK-1  Fix login error  [todo]",
+        ));
+}
+
+#[test]
+fn task_list_human_columns() {
+    let dir = tempfile::tempdir().unwrap();
+    tb_in(&dir)
+        .args(["project", "add", "--name", "Renai Sim"])
+        .assert()
+        .success();
+    tb_in(&dir)
+        .args([
+            "task",
+            "create",
+            "--project",
+            "renai-sim",
+            "--title",
+            "Fix login error",
+        ])
+        .assert()
+        .success();
+    tb_in(&dir)
+        .args(["task", "list", "--project", "renai-sim"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ID  COLUMN  URGENT  RUN  TITLE"))
+        .stdout(predicate::str::contains("TASK-1"))
+        .stdout(predicate::str::contains("todo"))
+        .stdout(predicate::str::contains("idle"))
+        .stdout(predicate::str::contains("Fix login error"));
+}
+
+#[test]
+fn project_list_json_uses_entities_not_entity() {
+    let dir = tempfile::tempdir().unwrap();
+    tb_in(&dir)
+        .args(["project", "add", "--name", "Renai Sim"])
+        .assert()
+        .success();
+    let out = tb_in(&dir)
+        .args(["project", "list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["ok"], true);
+    assert!(v.get("entity").is_none(), "list JSON must not fake entity");
+    assert_eq!(v["entities"][0]["slug"], "renai-sim");
+}
+
+#[test]
+fn json_commands_round_trip_board() {
+    let dir = tempfile::tempdir().unwrap();
+    let add = json_ok(&dir, &["project", "add", "--name", "Renai Sim"]);
+    assert_eq!(add["entity"]["slug"], "renai-sim");
+
+    let listed = json_ok(&dir, &["project", "list"]);
+    assert!(listed.get("entity").is_none());
+    assert_eq!(listed["entities"].as_array().unwrap().len(), 1);
+
+    json_ok(&dir, &["project", "show", "renai-sim"]);
+    json_ok(
+        &dir,
+        &[
+            "task",
+            "create",
+            "--project",
+            "renai-sim",
+            "--title",
+            "Fix login error",
+        ],
+    );
+    let tasks = json_ok(&dir, &["task", "list", "--project", "renai-sim"]);
+    assert!(tasks.get("entity").is_none());
+    assert_eq!(tasks["entities"][0]["display_id"], "TASK-1");
+
+    json_ok(&dir, &["task", "show", "TASK-1"]);
+    json_ok(
+        &dir,
+        &["task", "update", "TASK-1", "--title", "Fix login bug"],
+    );
+    json_ok(&dir, &["task", "move", "TASK-1", "in-progress"]);
+    json_ok(&dir, &["task", "urgent", "TASK-1", "on"]);
+    json_ok(&dir, &["task", "prioritize", "TASK-1", "--end"]);
+    json_ok(&dir, &["note", "add", "TASK-1", "--text", "check sessions"]);
+    json_ok(
+        &dir,
+        &["link", "add", "TASK-1", "--url", "https://example.com"],
+    );
+    let shown = json_ok(&dir, &["task", "show", "TASK-1"]);
+    let link_id = shown["entity"]["links"][0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    json_ok(&dir, &["run", "start", "TASK-1", "--agent", "codex"]);
+    json_ok(
+        &dir,
+        &["run", "update", "RUN-1", "--message", "adding tests"],
+    );
+    json_ok(&dir, &["run", "wait", "RUN-1", "--reason", "need spec"]);
+    json_ok(&dir, &["run", "finish", "RUN-1", "--summary", "done"]);
+    json_ok(
+        &dir,
+        &["project-note", "set", "renai-sim", "--text", "# Board"],
+    );
+    json_ok(&dir, &["project", "archive", "renai-sim"]);
+    json_ok(&dir, &["project", "unarchive", "renai-sim"]);
+    json_ok(&dir, &["link", "remove", &link_id]);
+    json_ok(&dir, &["task", "delete", "TASK-1"]);
+    let trash = json_ok(&dir, &["trash", "list"]);
+    assert_eq!(trash["entity"]["tasks"][0]["display_id"], "TASK-1");
+    json_ok(&dir, &["task", "restore", "TASK-1"]);
+    json_ok(&dir, &["undo"]);
+    let export = dir.path().join("export.sqlite3");
+    json_ok(&dir, &["backup", "export", export.to_str().unwrap()]);
+    json_ok(&dir, &["project", "delete", "renai-sim"]);
+    json_ok(&dir, &["project", "restore", "renai-sim"]);
+}
+
+fn json_ok(dir: &TempDir, args: &[&str]) -> serde_json::Value {
+    let mut argv = args.to_vec();
+    argv.push("--json");
+    let out = tb_in(dir)
+        .args(&argv)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["ok"], true, "stdout={v}");
+    v
+}

--- a/crates/cli/tests/help.rs
+++ b/crates/cli/tests/help.rs
@@ -1,0 +1,10 @@
+use assert_cmd::Command;
+
+#[test]
+fn help_lists_project_add() {
+    let mut cmd = Command::cargo_bin("taskboard").unwrap();
+    let out = String::from_utf8(cmd.arg("--help").output().unwrap().stdout).unwrap();
+    assert!(out.contains("project"), "help missing project:\n{out}");
+    assert!(out.contains("task"), "help missing task:\n{out}");
+    assert!(out.contains("run"), "help missing run:\n{out}");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #13

Plan 1 Task 11: `taskboard` CLI with clap, snake_case `--json`, human output, and a `serve` stub that exits 1.

Verify: `cargo test -p taskboard-cli -- --test-threads=1` and `cargo test -- --test-threads=1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

