### PR TITLE
feat: expose application use cases over localhost HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1092,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1136,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1955,14 +1991,18 @@ name = "taskboard-api"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "rand",
  "reqwest",
+ "serde",
  "serde_json",
  "taskboard-application",
+ "taskboard-core",
  "taskboard-store-sqlite",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1988,9 +2028,11 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "open",
  "predicates",
  "serde",
  "serde_json",
+ "taskboard-api",
  "taskboard-application",
  "taskboard-core",
  "taskboard-store-sqlite",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -6,11 +6,15 @@ license.workspace = true
 
 [dependencies]
 axum = "=0.7.9"
+chrono.workspace = true
 rand = "=0.8.5"
+serde.workspace = true
 serde_json.workspace = true
 taskboard-application = { path = "../application" }
+taskboard-core = { path = "../core" }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["net", "signal", "io-util", "sync"] }
+uuid.workspace = true
 
 [dev-dependencies]
 reqwest = { version = "=0.12.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/api/src/dto.rs
+++ b/crates/api/src/dto.rs
@@ -1,0 +1,366 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use taskboard_application::{SyncDelta, Trash};
+use taskboard_core::{
+    Activity, ActorKind, CardDisplayStatus, Column, EntityType, Link, LinkKind, Project, Run,
+    RunStatus, TaskDetail, TaskSummary,
+};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectDto {
+    pub id: Uuid,
+    pub slug: String,
+    pub name: String,
+    pub repo_path: Option<String>,
+    pub archived: bool,
+    pub note_markdown: String,
+    pub sort_order: i64,
+    pub revision: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl From<Project> for ProjectDto {
+    fn from(project: Project) -> Self {
+        Self {
+            id: project.id,
+            slug: project.slug,
+            name: project.name,
+            repo_path: project.repo_path,
+            archived: project.archived,
+            note_markdown: project.note_markdown,
+            sort_order: project.sort_order,
+            revision: project.revision,
+            created_at: project.created_at,
+            updated_at: project.updated_at,
+            deleted_at: project.deleted_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskSummaryDto {
+    pub id: Uuid,
+    pub display_id: String,
+    pub project_id: Uuid,
+    pub title: String,
+    pub column: Column,
+    pub urgent: bool,
+    pub revision: i64,
+    pub display_status: CardDisplayStatus,
+    pub run_message: Option<String>,
+}
+
+impl From<TaskSummary> for TaskSummaryDto {
+    fn from(task: TaskSummary) -> Self {
+        Self {
+            id: task.id,
+            display_id: task.display_id,
+            project_id: task.project_id,
+            title: task.title,
+            column: task.column,
+            urgent: task.urgent,
+            revision: task.revision,
+            display_status: task.display_status,
+            run_message: task.run_message,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkDto {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub kind: LinkKind,
+    pub value: String,
+    pub sort_order: i64,
+}
+
+impl From<Link> for LinkDto {
+    fn from(link: Link) -> Self {
+        Self {
+            id: link.id,
+            task_id: link.task_id,
+            kind: link.kind,
+            value: link.value,
+            sort_order: link.sort_order,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunDto {
+    pub id: Uuid,
+    pub display_id: String,
+    pub task_id: Uuid,
+    pub agent: String,
+    pub session_id: Option<String>,
+    pub status: RunStatus,
+    pub message: Option<String>,
+    pub waiting_reason: Option<String>,
+    pub summary: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    pub revision: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<Run> for RunDto {
+    fn from(run: Run) -> Self {
+        Self {
+            id: run.id,
+            display_id: run.display_id,
+            task_id: run.task_id,
+            agent: run.agent,
+            session_id: run.session_id,
+            status: run.status,
+            message: run.message,
+            waiting_reason: run.waiting_reason,
+            summary: run.summary,
+            started_at: run.started_at,
+            ended_at: run.ended_at,
+            revision: run.revision,
+            created_at: run.created_at,
+            updated_at: run.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityDto {
+    pub id: Uuid,
+    pub sequence: i64,
+    pub actor_kind: ActorKind,
+    pub actor_label: String,
+    pub operation: String,
+    pub entity_type: EntityType,
+    pub entity_id: Uuid,
+    pub previous_revision: Option<i64>,
+    pub before_json: Option<Value>,
+    pub after_json: Option<Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<Activity> for ActivityDto {
+    fn from(activity: Activity) -> Self {
+        Self {
+            id: activity.id,
+            sequence: activity.sequence,
+            actor_kind: activity.actor_kind,
+            actor_label: activity.actor_label,
+            operation: activity.operation,
+            entity_type: activity.entity_type,
+            entity_id: activity.entity_id,
+            previous_revision: activity.previous_revision,
+            before_json: activity.before_json,
+            after_json: activity.after_json,
+            created_at: activity.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskDetailDto {
+    pub id: Uuid,
+    pub display_id: String,
+    pub project_id: Uuid,
+    pub title: String,
+    pub column: Column,
+    pub urgent: bool,
+    pub revision: i64,
+    pub display_status: CardDisplayStatus,
+    pub run_message: Option<String>,
+    pub note_markdown: String,
+    pub links: Vec<LinkDto>,
+    pub runs: Vec<RunDto>,
+    pub recent_activities: Vec<ActivityDto>,
+}
+
+impl From<TaskDetail> for TaskDetailDto {
+    fn from(task: TaskDetail) -> Self {
+        Self {
+            id: task.id,
+            display_id: task.display_id,
+            project_id: task.project_id,
+            title: task.title,
+            column: task.column,
+            urgent: task.urgent,
+            revision: task.revision,
+            display_status: task.display_status,
+            run_message: task.run_message,
+            note_markdown: task.note_markdown,
+            links: task.links.into_iter().map(LinkDto::from).collect(),
+            runs: task.runs.into_iter().map(RunDto::from).collect(),
+            recent_activities: task
+                .recent_activities
+                .into_iter()
+                .map(ActivityDto::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncDeltaDto {
+    pub sequence: i64,
+    pub projects: Vec<ProjectDto>,
+    pub tasks: Vec<TaskDetailDto>,
+    pub runs: Vec<RunDto>,
+}
+
+impl From<SyncDelta> for SyncDeltaDto {
+    fn from(delta: SyncDelta) -> Self {
+        Self {
+            sequence: delta.sequence,
+            projects: delta.projects.into_iter().map(ProjectDto::from).collect(),
+            tasks: delta.tasks.into_iter().map(TaskDetailDto::from).collect(),
+            runs: delta.runs.into_iter().map(RunDto::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrashDto {
+    pub projects: Vec<ProjectDto>,
+    pub tasks: Vec<TaskSummaryDto>,
+}
+
+impl From<Trash> for TrashDto {
+    fn from(trash: Trash) -> Self {
+        Self {
+            projects: trash.projects.into_iter().map(ProjectDto::from).collect(),
+            tasks: trash.tasks.into_iter().map(TaskSummaryDto::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateProjectBody {
+    pub name: String,
+    pub repo_path: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PatchProjectBody {
+    pub name: Option<String>,
+    pub repo_path: Option<String>,
+    pub slug: Option<String>,
+    pub archived: Option<bool>,
+    pub note_markdown: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReorderProjectsBody {
+    pub slugs: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTaskBody {
+    pub title: String,
+    pub column: Option<Column>,
+    #[serde(default)]
+    pub urgent: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PatchTaskBody {
+    pub title: Option<String>,
+    pub note_markdown: Option<String>,
+    pub urgent: Option<bool>,
+    pub column: Option<Column>,
+    pub before_display_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddLinkBody {
+    pub kind: LinkKind,
+    pub value: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartRunBody {
+    pub agent: String,
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RunOp {
+    Update,
+    Wait,
+    Fail,
+    Finish,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PatchRunBody {
+    pub op: RunOp,
+    pub message: Option<String>,
+    pub reason: Option<String>,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupBody {
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SyncQuery {
+    pub after: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListProjectsQuery {
+    pub archived: Option<bool>,
+}
+
+pub fn json_keys_to_camel(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, nested)| (snake_to_camel(&key), json_keys_to_camel(nested)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(json_keys_to_camel).collect()),
+        other => other,
+    }
+}
+
+fn snake_to_camel(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut upper = false;
+    for ch in raw.chars() {
+        if ch == '_' {
+            upper = true;
+        } else if upper {
+            out.extend(ch.to_uppercase());
+            upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/crates/api/src/dto.rs
+++ b/crates/api/src/dto.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use taskboard_application::{SyncDelta, Trash};
 use taskboard_core::{
@@ -286,7 +286,18 @@ pub struct PatchTaskBody {
     pub note_markdown: Option<String>,
     pub urgent: Option<bool>,
     pub column: Option<Column>,
-    pub before_display_id: Option<String>,
+    /// Absent: do not reorder. `null`: move to end. String: place before that card.
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    pub before_display_id: Option<Option<String>>,
+}
+
+/// Distinguishes JSON field absent (`None`) from explicit `null` (`Some(None)`).
+fn deserialize_present_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,4 +1,6 @@
+mod dto;
 mod origin;
+mod routes;
 mod server;
 mod session;
 

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -95,6 +95,10 @@ fn if_match(headers: &HeaderMap) -> Result<Option<i64>, Response> {
     raw.parse().map(Some).map_err(|_| invalid_if_match())
 }
 
+fn advance_if_match(updated_revision: i64) -> Option<i64> {
+    Some(updated_revision)
+}
+
 fn invalid_if_match() -> Response {
     app_error(AppError::Validation {
         field: "If-Match".into(),
@@ -249,7 +253,7 @@ async fn patch_project(
             .await
             .map_err(app_error)?;
         slug = updated.slug.clone();
-        revision = Some(updated.revision);
+        revision = advance_if_match(updated.revision);
         project = Some(updated);
     }
     if let Some(archived) = body.archived {
@@ -258,7 +262,7 @@ async fn patch_project(
             .project_archive(&actor, &slug, archived, revision)
             .await
             .map_err(app_error)?;
-        revision = Some(updated.revision);
+        revision = advance_if_match(updated.revision);
         project = Some(updated);
     }
     if let Some(note_markdown) = body.note_markdown {
@@ -405,7 +409,7 @@ async fn patch_task(
             )
             .await
             .map_err(app_error)?;
-        revision = Some(updated.revision);
+        revision = advance_if_match(updated.revision);
         task = Some(updated);
     }
     if let Some(note_markdown) = body.note_markdown {
@@ -414,7 +418,7 @@ async fn patch_task(
             .task_note_set(&actor, &display_id, note_markdown, revision)
             .await
             .map_err(app_error)?;
-        revision = Some(updated.revision);
+        revision = advance_if_match(updated.revision);
         task = Some(updated);
     }
     if let Some(urgent) = body.urgent {
@@ -423,7 +427,7 @@ async fn patch_task(
             .task_urgent(&actor, &display_id, urgent, revision)
             .await
             .map_err(app_error)?;
-        revision = Some(updated.revision);
+        revision = advance_if_match(updated.revision);
         task = Some(updated);
     }
     if let Some(column) = body.column {
@@ -432,17 +436,20 @@ async fn patch_task(
             .task_move(&actor, &display_id, column, revision)
             .await
             .map_err(app_error)?;
-        revision = Some(updated.revision);
+        revision = advance_if_match(updated.revision);
         task = Some(updated);
     }
     if let Some(before_display_id) = body.before_display_id {
-        task = Some(
-            state
-                .app
-                .task_reorder(&actor, &display_id, before_display_id.as_deref(), revision)
-                .await
-                .map_err(app_error)?,
-        );
+        let updated = state
+            .app
+            .task_reorder(&actor, &display_id, before_display_id.as_deref(), revision)
+            .await
+            .map_err(app_error)?;
+        #[allow(unused_assignments)]
+        {
+            revision = advance_if_match(updated.revision);
+        }
+        task = Some(updated);
     }
     let task = match task {
         Some(task) => task,
@@ -669,4 +676,48 @@ async fn backup_import(
         .await
         .map_err(app_error)?;
     Ok(ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::advance_if_match;
+
+    fn chain_revisions<E>(
+        mut revision: Option<i64>,
+        first: impl FnOnce(Option<i64>) -> Result<i64, E>,
+        second: impl FnOnce(Option<i64>) -> Result<i64, E>,
+    ) -> Result<Option<i64>, E> {
+        revision = advance_if_match(first(revision)?);
+        revision = advance_if_match(second(revision)?);
+        Ok(revision)
+    }
+
+    #[test]
+    fn advance_if_match_keeps_revision_not_none() {
+        let n = 2_i64;
+        assert_eq!(advance_if_match(n), Some(n));
+        assert_ne!(advance_if_match(n), None);
+    }
+
+    #[test]
+    fn chain_revisions_second_op_sees_advanced_if_match() {
+        let mut first_seen = None;
+        let mut second_seen = None;
+        let result = chain_revisions(
+            Some(1),
+            |rev| {
+                first_seen = rev;
+                Ok::<_, ()>(2)
+            },
+            |rev| {
+                second_seen = rev;
+                Ok::<_, ()>(3)
+            },
+        );
+        assert_eq!(result, Ok(Some(3)));
+        assert_eq!(first_seen, Some(1));
+        assert_eq!(second_seen, Some(2));
+        assert_ne!(second_seen, None);
+        assert_ne!(second_seen, Some(1));
+    }
 }

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -249,18 +249,17 @@ async fn patch_project(
             .await
             .map_err(app_error)?;
         slug = updated.slug.clone();
+        revision = Some(updated.revision);
         project = Some(updated);
-        revision = None;
     }
     if let Some(archived) = body.archived {
-        project = Some(
-            state
-                .app
-                .project_archive(&actor, &slug, archived, revision)
-                .await
-                .map_err(app_error)?,
-        );
-        revision = None;
+        let updated = state
+            .app
+            .project_archive(&actor, &slug, archived, revision)
+            .await
+            .map_err(app_error)?;
+        revision = Some(updated.revision);
+        project = Some(updated);
     }
     if let Some(note_markdown) = body.note_markdown {
         project = Some(
@@ -394,62 +393,53 @@ async fn patch_task(
     let mut revision = if_match(&headers)?;
     let mut task = None;
     if body.title.is_some() {
-        task = Some(
-            state
-                .app
-                .task_update(
-                    &actor,
-                    TaskUpdate {
-                        display_id: display_id.clone(),
-                        title: body.title,
-                        revision,
-                    },
-                )
-                .await
-                .map_err(app_error)?,
-        );
-        revision = None;
+        let updated = state
+            .app
+            .task_update(
+                &actor,
+                TaskUpdate {
+                    display_id: display_id.clone(),
+                    title: body.title,
+                    revision,
+                },
+            )
+            .await
+            .map_err(app_error)?;
+        revision = Some(updated.revision);
+        task = Some(updated);
     }
     if let Some(note_markdown) = body.note_markdown {
-        task = Some(
-            state
-                .app
-                .task_note_set(&actor, &display_id, note_markdown, revision)
-                .await
-                .map_err(app_error)?,
-        );
-        revision = None;
+        let updated = state
+            .app
+            .task_note_set(&actor, &display_id, note_markdown, revision)
+            .await
+            .map_err(app_error)?;
+        revision = Some(updated.revision);
+        task = Some(updated);
     }
     if let Some(urgent) = body.urgent {
-        task = Some(
-            state
-                .app
-                .task_urgent(&actor, &display_id, urgent, revision)
-                .await
-                .map_err(app_error)?,
-        );
-        revision = None;
+        let updated = state
+            .app
+            .task_urgent(&actor, &display_id, urgent, revision)
+            .await
+            .map_err(app_error)?;
+        revision = Some(updated.revision);
+        task = Some(updated);
     }
     if let Some(column) = body.column {
-        task = Some(
-            state
-                .app
-                .task_move(&actor, &display_id, column, revision)
-                .await
-                .map_err(app_error)?,
-        );
-        revision = None;
+        let updated = state
+            .app
+            .task_move(&actor, &display_id, column, revision)
+            .await
+            .map_err(app_error)?;
+        revision = Some(updated.revision);
+        task = Some(updated);
     }
     if let Some(before_display_id) = body.before_display_id {
         task = Some(
             state
                 .app
-                .task_reorder(
-                    &actor,
-                    &display_id,
-                    Some(before_display_id.as_str()),
-                    revision,
-                )
+                .task_reorder(&actor, &display_id, before_display_id.as_deref(), revision)
                 .await
                 .map_err(app_error)?,
         );

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -1,0 +1,682 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get, patch, post};
+use axum::{Json, Router};
+use serde::Serialize;
+use serde_json::{json, Value};
+use taskboard_application::{
+    Actor, AppError, LinkAdd, ProjectAdd, ProjectUpdate, RunFail, RunFinish, RunStart, RunUpdate,
+    RunWait, TaskCreate, TaskUpdate,
+};
+use taskboard_core::ActorKind;
+use uuid::Uuid;
+
+use crate::dto::{
+    json_keys_to_camel, AddLinkBody, BackupBody, CreateProjectBody, CreateTaskBody,
+    ListProjectsQuery, PatchProjectBody, PatchRunBody, PatchTaskBody, ProjectDto,
+    ReorderProjectsBody, RunDto, RunOp, StartRunBody, SyncDeltaDto, SyncQuery, TaskDetailDto,
+    TrashDto,
+};
+use crate::origin::origin_allowed;
+use crate::server::{
+    forbidden_origin, session_from_header, session_from_header_or_cookie, unauthorized, AppState,
+};
+
+pub(crate) fn api_router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/bootstrap", get(bootstrap))
+        .route("/api/v1/sync", get(sync))
+        .route("/api/v1/projects", get(list_projects).post(create_project))
+        .route("/api/v1/projects/reorder", post(reorder_projects))
+        .route(
+            "/api/v1/projects/:slug/tasks",
+            get(list_tasks).post(create_task),
+        )
+        .route("/api/v1/projects/:slug/restore", post(restore_project))
+        .route(
+            "/api/v1/projects/:slug",
+            patch(patch_project).delete(delete_project),
+        )
+        .route("/api/v1/tasks/:display_id/links", post(add_link))
+        .route("/api/v1/tasks/:display_id/runs", post(start_run))
+        .route("/api/v1/tasks/:display_id/restore", post(restore_task))
+        .route(
+            "/api/v1/tasks/:display_id",
+            get(show_task).patch(patch_task).delete(delete_task),
+        )
+        .route("/api/v1/links/:id", delete(remove_link))
+        .route("/api/v1/runs/:display_id", patch(patch_run))
+        .route("/api/v1/trash", get(list_trash))
+        .route("/api/v1/undo", post(undo))
+        .route("/api/v1/backups/export", post(backup_export))
+        .route("/api/v1/backups/import", post(backup_import))
+}
+
+type ApiResult = Result<Response, Response>;
+
+fn web_actor() -> Actor {
+    Actor {
+        kind: ActorKind::Web,
+        label: "local-web".into(),
+    }
+}
+
+fn require_read(state: &AppState, headers: &HeaderMap) -> Result<(), Response> {
+    if session_from_header_or_cookie(headers, &state.session.0) {
+        Ok(())
+    } else {
+        Err(unauthorized())
+    }
+}
+
+fn require_mutation(state: &AppState, headers: &HeaderMap) -> Result<(), Response> {
+    if !session_from_header(headers, &state.session.0) {
+        return Err(unauthorized());
+    }
+    if !origin_allowed(headers.get(header::ORIGIN), state.port) {
+        return Err(forbidden_origin());
+    }
+    Ok(())
+}
+
+fn if_match(headers: &HeaderMap) -> Result<Option<i64>, Response> {
+    let Some(value) = headers.get("If-Match") else {
+        return Ok(None);
+    };
+    let raw = value.to_str().map_err(|_| invalid_if_match())?;
+    let raw = raw.trim().trim_matches('"').trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    raw.parse().map(Some).map_err(|_| invalid_if_match())
+}
+
+fn invalid_if_match() -> Response {
+    app_error(AppError::Validation {
+        field: "If-Match".into(),
+        message: "must be a revision number".into(),
+    })
+}
+
+fn missing_field(field: &str) -> Response {
+    app_error(AppError::Validation {
+        field: field.into(),
+        message: "is required".into(),
+    })
+}
+
+fn entity<T: Serialize>(entity: T, revision: i64) -> Response {
+    Json(json!({
+        "ok": true,
+        "entity": entity,
+        "revision": revision,
+    }))
+    .into_response()
+}
+
+fn entities<T: Serialize>(entities: T) -> Response {
+    Json(json!({
+        "ok": true,
+        "entities": entities,
+    }))
+    .into_response()
+}
+
+fn ok() -> Response {
+    Json(json!({ "ok": true })).into_response()
+}
+
+fn app_error(err: AppError) -> Response {
+    let status = match &err {
+        AppError::Validation { .. } => StatusCode::BAD_REQUEST,
+        AppError::NotFound { .. } => StatusCode::NOT_FOUND,
+        AppError::DuplicateSlug { .. }
+        | AppError::RevisionConflict { .. }
+        | AppError::UndoConflict { .. }
+        | AppError::DifferentColumn { .. } => StatusCode::CONFLICT,
+        AppError::DatabaseBusy => StatusCode::SERVICE_UNAVAILABLE,
+        AppError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    let mut body = json!({
+        "code": err.code(),
+        "message": err.to_string(),
+    });
+    match err {
+        AppError::Validation { field, .. } => {
+            body["field"] = json!(field);
+        }
+        AppError::DuplicateSlug { slug } => {
+            body["slug"] = json!(slug);
+        }
+        AppError::RevisionConflict { current } | AppError::UndoConflict { current } => {
+            body["current"] = json_keys_to_camel(current);
+        }
+        _ => {}
+    }
+    (status, Json(json!({ "error": body }))).into_response()
+}
+
+async fn bootstrap(State(state): State<Arc<AppState>>, headers: HeaderMap) -> ApiResult {
+    require_read(&state, &headers)?;
+    let activity_sequence = state.app.activity_head().await.unwrap_or(0);
+    Ok(Json(json!({
+        "session": state.session.0,
+        "activitySequence": activity_sequence,
+    }))
+    .into_response())
+}
+
+async fn sync(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(query): Query<SyncQuery>,
+) -> ApiResult {
+    require_read(&state, &headers)?;
+    let delta = state.app.sync(query.after).await.map_err(app_error)?;
+    Ok(Json(SyncDeltaDto::from(delta)).into_response())
+}
+
+async fn list_projects(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(query): Query<ListProjectsQuery>,
+) -> ApiResult {
+    require_read(&state, &headers)?;
+    let include_archived = query.archived.unwrap_or(false);
+    let projects = state
+        .app
+        .project_list(include_archived)
+        .await
+        .map_err(app_error)?;
+    Ok(entities(
+        projects
+            .into_iter()
+            .map(ProjectDto::from)
+            .collect::<Vec<_>>(),
+    ))
+}
+
+async fn create_project(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<CreateProjectBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let project = state
+        .app
+        .project_add(
+            &web_actor(),
+            ProjectAdd {
+                name: body.name,
+                repo_path: body.repo_path,
+                slug: body.slug,
+            },
+        )
+        .await
+        .map_err(app_error)?;
+    let dto = ProjectDto::from(project);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn patch_project(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(mut slug): Path<String>,
+    Json(body): Json<PatchProjectBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let actor = web_actor();
+    let mut revision = if_match(&headers)?;
+    let mut project = None;
+    if body.name.is_some() || body.repo_path.is_some() || body.slug.is_some() {
+        let updated = state
+            .app
+            .project_update(
+                &actor,
+                ProjectUpdate {
+                    slug: slug.clone(),
+                    name: body.name,
+                    repo_path: body.repo_path,
+                    new_slug: body.slug,
+                    revision,
+                },
+            )
+            .await
+            .map_err(app_error)?;
+        slug = updated.slug.clone();
+        project = Some(updated);
+        revision = None;
+    }
+    if let Some(archived) = body.archived {
+        project = Some(
+            state
+                .app
+                .project_archive(&actor, &slug, archived, revision)
+                .await
+                .map_err(app_error)?,
+        );
+        revision = None;
+    }
+    if let Some(note_markdown) = body.note_markdown {
+        project = Some(
+            state
+                .app
+                .project_note_set(&actor, &slug, note_markdown, revision)
+                .await
+                .map_err(app_error)?,
+        );
+    }
+    let project = match project {
+        Some(project) => project,
+        None => state.app.project_show(&slug).await.map_err(app_error)?,
+    };
+    let dto = ProjectDto::from(project);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn reorder_projects(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<ReorderProjectsBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let projects = state
+        .app
+        .project_reorder(&web_actor(), &body.slugs)
+        .await
+        .map_err(app_error)?;
+    Ok(entities(
+        projects
+            .into_iter()
+            .map(ProjectDto::from)
+            .collect::<Vec<_>>(),
+    ))
+}
+
+async fn delete_project(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(slug): Path<String>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let project = state
+        .app
+        .project_delete(&web_actor(), &slug, if_match(&headers)?)
+        .await
+        .map_err(app_error)?;
+    let dto = ProjectDto::from(project);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn restore_project(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(slug): Path<String>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let project = state
+        .app
+        .project_restore(&web_actor(), &slug)
+        .await
+        .map_err(app_error)?;
+    let dto = ProjectDto::from(project);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn list_tasks(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(slug): Path<String>,
+) -> ApiResult {
+    require_read(&state, &headers)?;
+    let tasks = state.app.task_list(&slug).await.map_err(app_error)?;
+    Ok(entities(
+        tasks
+            .into_iter()
+            .map(crate::dto::TaskSummaryDto::from)
+            .collect::<Vec<_>>(),
+    ))
+}
+
+async fn create_task(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(slug): Path<String>,
+    Json(body): Json<CreateTaskBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let task = state
+        .app
+        .task_create(
+            &web_actor(),
+            TaskCreate {
+                project_slug: slug,
+                title: body.title,
+                column: body.column,
+                urgent: body.urgent,
+            },
+        )
+        .await
+        .map_err(app_error)?;
+    let dto = TaskDetailDto::from(task);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn show_task(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(display_id): Path<String>,
+) -> ApiResult {
+    require_read(&state, &headers)?;
+    let task = state.app.task_show(&display_id).await.map_err(app_error)?;
+    let dto = TaskDetailDto::from(task);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn patch_task(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(display_id): Path<String>,
+    Json(body): Json<PatchTaskBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let actor = web_actor();
+    let mut revision = if_match(&headers)?;
+    let mut task = None;
+    if body.title.is_some() {
+        task = Some(
+            state
+                .app
+                .task_update(
+                    &actor,
+                    TaskUpdate {
+                        display_id: display_id.clone(),
+                        title: body.title,
+                        revision,
+                    },
+                )
+                .await
+                .map_err(app_error)?,
+        );
+        revision = None;
+    }
+    if let Some(note_markdown) = body.note_markdown {
+        task = Some(
+            state
+                .app
+                .task_note_set(&actor, &display_id, note_markdown, revision)
+                .await
+                .map_err(app_error)?,
+        );
+        revision = None;
+    }
+    if let Some(urgent) = body.urgent {
+        task = Some(
+            state
+                .app
+                .task_urgent(&actor, &display_id, urgent, revision)
+                .await
+                .map_err(app_error)?,
+        );
+        revision = None;
+    }
+    if let Some(column) = body.column {
+        task = Some(
+            state
+                .app
+                .task_move(&actor, &display_id, column, revision)
+                .await
+                .map_err(app_error)?,
+        );
+        revision = None;
+    }
+    if let Some(before_display_id) = body.before_display_id {
+        task = Some(
+            state
+                .app
+                .task_reorder(
+                    &actor,
+                    &display_id,
+                    Some(before_display_id.as_str()),
+                    revision,
+                )
+                .await
+                .map_err(app_error)?,
+        );
+    }
+    let task = match task {
+        Some(task) => task,
+        None => state.app.task_show(&display_id).await.map_err(app_error)?,
+    };
+    let dto = TaskDetailDto::from(task);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn delete_task(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(display_id): Path<String>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let task = state
+        .app
+        .task_delete(&web_actor(), &display_id, if_match(&headers)?)
+        .await
+        .map_err(app_error)?;
+    let dto = TaskDetailDto::from(task);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn restore_task(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(display_id): Path<String>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let task = state
+        .app
+        .task_restore(&web_actor(), &display_id)
+        .await
+        .map_err(app_error)?;
+    let dto = TaskDetailDto::from(task);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn add_link(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(display_id): Path<String>,
+    Json(body): Json<AddLinkBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let task = state
+        .app
+        .link_add(
+            &web_actor(),
+            LinkAdd {
+                task_display_id: display_id,
+                kind: body.kind,
+                value: body.value,
+                revision: if_match(&headers)?,
+            },
+        )
+        .await
+        .map_err(app_error)?;
+    let dto = TaskDetailDto::from(task);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn remove_link(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id): Path<Uuid>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let task = state
+        .app
+        .link_remove(&web_actor(), id, if_match(&headers)?)
+        .await
+        .map_err(app_error)?;
+    let dto = TaskDetailDto::from(task);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn start_run(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(display_id): Path<String>,
+    Json(body): Json<StartRunBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let run = state
+        .app
+        .run_start(
+            &web_actor(),
+            RunStart {
+                task_display_id: display_id,
+                agent: body.agent,
+                session_id: body.session_id,
+            },
+        )
+        .await
+        .map_err(app_error)?;
+    let dto = RunDto::from(run);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn patch_run(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(display_id): Path<String>,
+    Json(body): Json<PatchRunBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let actor = web_actor();
+    let revision = if_match(&headers)?;
+    let run = match body.op {
+        RunOp::Update => {
+            state
+                .app
+                .run_update(
+                    &actor,
+                    RunUpdate {
+                        run_display_id: display_id,
+                        message: body.message,
+                        revision,
+                    },
+                )
+                .await
+        }
+        RunOp::Wait => {
+            let reason = body.reason.ok_or_else(|| missing_field("reason"))?;
+            state
+                .app
+                .run_wait(
+                    &actor,
+                    RunWait {
+                        run_display_id: display_id,
+                        reason,
+                        revision,
+                    },
+                )
+                .await
+        }
+        RunOp::Fail => {
+            let summary = body.summary.ok_or_else(|| missing_field("summary"))?;
+            state
+                .app
+                .run_fail(
+                    &actor,
+                    RunFail {
+                        run_display_id: display_id,
+                        summary,
+                        revision,
+                    },
+                )
+                .await
+        }
+        RunOp::Finish => {
+            let summary = body.summary.ok_or_else(|| missing_field("summary"))?;
+            state
+                .app
+                .run_finish(
+                    &actor,
+                    RunFinish {
+                        run_display_id: display_id,
+                        summary,
+                        revision,
+                    },
+                )
+                .await
+        }
+    }
+    .map_err(app_error)?;
+    let dto = RunDto::from(run);
+    let revision = dto.revision;
+    Ok(entity(dto, revision))
+}
+
+async fn list_trash(State(state): State<Arc<AppState>>, headers: HeaderMap) -> ApiResult {
+    require_read(&state, &headers)?;
+    let trash = state.app.trash_list().await.map_err(app_error)?;
+    Ok(Json(json!({
+        "ok": true,
+        "entity": TrashDto::from(trash),
+    }))
+    .into_response())
+}
+
+async fn undo(State(state): State<Arc<AppState>>, headers: HeaderMap) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    let result = state.app.undo(&web_actor()).await.map_err(app_error)?;
+    let revision = result
+        .entity
+        .get("revision")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    Ok(entity(json_keys_to_camel(result.entity), revision))
+}
+
+async fn backup_export(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<BackupBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    state
+        .app
+        .backup_export(&PathBuf::from(body.path))
+        .await
+        .map_err(app_error)?;
+    Ok(ok())
+}
+
+async fn backup_import(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<BackupBody>,
+) -> ApiResult {
+    require_mutation(&state, &headers)?;
+    state
+        .app
+        .backup_import(&PathBuf::from(body.path))
+        .await
+        .map_err(app_error)?;
+    Ok(ok())
+}

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -4,18 +4,17 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
 use axum::response::{Html, IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::get;
 use axum::{Json, Router};
 use serde_json::json;
 use taskboard_application::App;
 use thiserror::Error;
 use tokio::net::TcpListener;
 
-use crate::origin::origin_allowed;
 use crate::session::{generate_session, SessionToken};
 
 const SESSION_COOKIE: &str = "taskboard_session";
-const SESSION_HEADER: &str = "X-Taskboard-Session";
+pub(crate) const SESSION_HEADER: &str = "X-Taskboard-Session";
 const HTML_SHELL: &str = r#"<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -40,10 +39,10 @@ pub enum ApiError {
     },
 }
 
-struct AppState {
-    app: App,
-    session: SessionToken,
-    port: u16,
+pub(crate) struct AppState {
+    pub(crate) app: App,
+    pub(crate) session: SessionToken,
+    pub(crate) port: u16,
 }
 
 pub async fn serve(app: App, addr: SocketAddr, open: bool) -> Result<SocketAddr, ApiError> {
@@ -74,8 +73,7 @@ pub async fn serve(app: App, addr: SocketAddr, open: bool) -> Result<SocketAddr,
 fn router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/", get(html_shell))
-        .route("/api/v1/bootstrap", get(bootstrap))
-        .route("/api/v1/projects", post(dummy_create_project))
+        .merge(crate::routes::api_router())
         .with_state(state)
 }
 
@@ -92,36 +90,14 @@ async fn html_shell(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     (headers, Html(HTML_SHELL))
 }
 
-async fn bootstrap(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
-    if !session_from_header_or_cookie(&headers, &state.session.0) {
-        return unauthorized();
-    }
-    let activity_sequence = state.app.activity_head().await.unwrap_or(0);
-    Json(json!({
-        "session": state.session.0,
-        "activitySequence": activity_sequence,
-    }))
-    .into_response()
-}
-
-async fn dummy_create_project(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
-    if !session_from_header(&headers, &state.session.0) {
-        return unauthorized();
-    }
-    if !origin_allowed(headers.get(header::ORIGIN), state.port) {
-        return forbidden_origin();
-    }
-    Json(json!({ "ok": true })).into_response()
-}
-
-fn session_from_header(headers: &HeaderMap, expected: &str) -> bool {
+pub(crate) fn session_from_header(headers: &HeaderMap, expected: &str) -> bool {
     headers
         .get(SESSION_HEADER)
         .and_then(|value| value.to_str().ok())
         .is_some_and(|token| token == expected)
 }
 
-fn session_from_header_or_cookie(headers: &HeaderMap, expected: &str) -> bool {
+pub(crate) fn session_from_header_or_cookie(headers: &HeaderMap, expected: &str) -> bool {
     if session_from_header(headers, expected) {
         return true;
     }
@@ -138,7 +114,7 @@ fn session_from_header_or_cookie(headers: &HeaderMap, expected: &str) -> bool {
         })
 }
 
-fn unauthorized() -> Response {
+pub(crate) fn unauthorized() -> Response {
     (
         StatusCode::UNAUTHORIZED,
         Json(json!({ "error": { "code": "unauthorized" } })),
@@ -146,7 +122,7 @@ fn unauthorized() -> Response {
         .into_response()
 }
 
-fn forbidden_origin() -> Response {
+pub(crate) fn forbidden_origin() -> Response {
     (
         StatusCode::FORBIDDEN,
         Json(json!({ "error": { "code": "forbidden_origin" } })),

--- a/crates/api/tests/routes.rs
+++ b/crates/api/tests/routes.rs
@@ -1,0 +1,144 @@
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde_json::json;
+
+struct TestServer {
+    base: String,
+    token: String,
+    _tmp: tempfile::TempDir,
+}
+
+fn authed(s: &TestServer) -> reqwest::Client {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "X-Taskboard-Session",
+        HeaderValue::from_str(&s.token).unwrap(),
+    );
+    headers.insert("Origin", HeaderValue::from_str(&s.base).unwrap());
+    reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .unwrap()
+}
+
+async fn start_test_server() -> TestServer {
+    use std::net::SocketAddr;
+
+    use taskboard_api::serve;
+    use taskboard_application::{App, SystemClock};
+    use taskboard_store_sqlite::{open_db, SqliteStore};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let pool = open_db(tmp.path()).await.unwrap();
+    let store = SqliteStore::new(pool, tmp.path());
+    let app = App::new(store, SystemClock);
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let bound = serve(app, addr, false).await.unwrap();
+    let base = format!("http://127.0.0.1:{}", bound.port());
+
+    let res = reqwest::Client::new()
+        .get(format!("{base}/"))
+        .send()
+        .await
+        .unwrap();
+    let cookie = res
+        .headers()
+        .get("set-cookie")
+        .and_then(|v| v.to_str().ok())
+        .expect("GET / must set a session cookie");
+    let token = cookie
+        .split(';')
+        .next()
+        .and_then(|part| part.trim().strip_prefix("taskboard_session="))
+        .expect("session cookie named taskboard_session")
+        .to_string();
+
+    TestServer {
+        base,
+        token,
+        _tmp: tmp,
+    }
+}
+
+async fn seeded_task_server() -> TestServer {
+    let s = start_test_server().await;
+    let client = authed(&s);
+    let proj = client
+        .post(format!("{}/api/v1/projects", s.base))
+        .json(&json!({"name": "Renai Sim"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(proj.status(), 200);
+    let task = client
+        .post(format!("{}/api/v1/projects/renai-sim/tasks", s.base))
+        .json(&json!({"title": "Fix login error"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(task.status(), 200);
+    s
+}
+
+#[tokio::test]
+async fn create_project_and_task_round_trip() {
+    let s = start_test_server().await;
+    let client = authed(&s);
+    let proj = client
+        .post(format!("{}/api/v1/projects", s.base))
+        .json(&json!({"name": "Renai Sim"}))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(proj["entity"]["slug"], "renai-sim");
+    let task = client
+        .post(format!("{}/api/v1/projects/renai-sim/tasks", s.base))
+        .json(&json!({"title": "Fix login error"}))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(task["entity"]["displayId"], "TASK-1");
+}
+
+#[tokio::test]
+async fn if_match_conflict() {
+    let s = seeded_task_server().await;
+    let res = authed(&s)
+        .patch(format!("{}/api/v1/tasks/TASK-1", s.base))
+        .header("If-Match", "0")
+        .json(&json!({"title": "Nope"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 409);
+}
+
+#[tokio::test]
+async fn sync_after_zero_then_after_head() {
+    let s = seeded_task_server().await;
+    let head = authed(&s)
+        .get(format!("{}/api/v1/sync?after=0", s.base))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let seq = head["sequence"].as_i64().unwrap();
+    assert!(seq >= 1);
+    let again = authed(&s)
+        .get(format!("{}/api/v1/sync?after={}", s.base, seq))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(again["sequence"], seq);
+    assert!(again["projects"].as_array().unwrap().is_empty());
+}

--- a/crates/api/tests/routes.rs
+++ b/crates/api/tests/routes.rs
@@ -142,3 +142,110 @@ async fn sync_after_zero_then_after_head() {
     assert_eq!(again["sequence"], seq);
     assert!(again["projects"].as_array().unwrap().is_empty());
 }
+
+async fn task_display_ids(s: &TestServer, slug: &str) -> Vec<String> {
+    let listed = authed(s)
+        .get(format!("{}/api/v1/projects/{slug}/tasks", s.base))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    listed["entities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|task| task["displayId"].as_str().unwrap().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn patch_task_before_display_id_null_moves_card_to_end() {
+    let s = start_test_server().await;
+    let client = authed(&s);
+    assert_eq!(
+        client
+            .post(format!("{}/api/v1/projects", s.base))
+            .json(&json!({"name": "Renai Sim"}))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+    for title in ["First", "Second", "Third"] {
+        assert_eq!(
+            client
+                .post(format!("{}/api/v1/projects/renai-sim/tasks", s.base))
+                .json(&json!({ "title": title }))
+                .send()
+                .await
+                .unwrap()
+                .status(),
+            200
+        );
+    }
+    assert_eq!(
+        task_display_ids(&s, "renai-sim").await,
+        ["TASK-1", "TASK-2", "TASK-3"]
+    );
+
+    let res = client
+        .patch(format!("{}/api/v1/tasks/TASK-1", s.base))
+        .json(&json!({ "beforeDisplayId": null }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    assert_eq!(
+        task_display_ids(&s, "renai-sim").await,
+        ["TASK-2", "TASK-3", "TASK-1"]
+    );
+}
+
+#[tokio::test]
+async fn patch_task_chains_if_match_across_fields() {
+    let s = seeded_task_server().await;
+    let client = authed(&s);
+    let shown = client
+        .get(format!("{}/api/v1/tasks/TASK-1", s.base))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let revision = shown["entity"]["revision"].as_i64().unwrap();
+
+    let ok = client
+        .patch(format!("{}/api/v1/tasks/TASK-1", s.base))
+        .header("If-Match", revision.to_string())
+        .json(&json!({ "title": "Updated title", "urgent": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), 200);
+    let body = ok.json::<serde_json::Value>().await.unwrap();
+    assert_eq!(body["entity"]["title"], "Updated title");
+    assert_eq!(body["entity"]["urgent"], true);
+
+    let conflict = client
+        .patch(format!("{}/api/v1/tasks/TASK-1", s.base))
+        .header("If-Match", revision.to_string())
+        .json(&json!({ "title": "Should not apply", "urgent": false }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), 409);
+    let shown = client
+        .get(format!("{}/api/v1/tasks/TASK-1", s.base))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(shown["entity"]["title"], "Updated title");
+    assert_eq!(shown["entity"]["urgent"], true);
+}

--- a/crates/api/tests/routes.rs
+++ b/crates/api/tests/routes.rs
@@ -229,6 +229,7 @@ async fn patch_task_chains_if_match_across_fields() {
     let body = ok.json::<serde_json::Value>().await.unwrap();
     assert_eq!(body["entity"]["title"], "Updated title");
     assert_eq!(body["entity"]["urgent"], true);
+    assert_eq!(body["revision"], revision + 2);
 
     let conflict = client
         .patch(format!("{}/api/v1/tasks/TASK-1", s.base))

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,10 +14,12 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 taskboard-application = { path = "../application" }
+taskboard-api = { path = "../api" }
 taskboard-core = { path = "../core" }
 taskboard-store-sqlite = { path = "../store-sqlite" }
 tokio.workspace = true
 uuid.workspace = true
+open = "=5.3.2"
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -75,7 +75,7 @@ pub enum Command {
     /// Database backup
     #[command(subcommand)]
     Backup(BackupCommand),
-    /// Start the local HTTP UI (not available in this build)
+    /// Start the local HTTP UI
     Serve(ServeArgs),
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,8 @@ mod args;
 mod data_dir;
 mod output;
 
+use std::io::Write;
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
 
 use chrono::Utc;
@@ -27,11 +29,6 @@ async fn main() {
 }
 
 async fn run(cli: Cli) -> Result<(), i32> {
-    if matches!(cli.command, Command::Serve(_)) {
-        eprintln!("error: tb serve is not available in this build");
-        return Err(1);
-    }
-
     let json = cli.json;
     let data_dir = data_dir::resolve(cli.data_dir.as_deref());
     let pool = open_db(&data_dir)
@@ -42,8 +39,37 @@ async fn run(cli: Cli) -> Result<(), i32> {
     app.purge_expired_trash(Utc::now())
         .await
         .map_err(|err| output::print_error(&err, json))?;
+
+    if let Command::Serve(args) = cli.command {
+        return serve_cmd(app, args.port, args.open).await;
+    }
+
     let actor = cli.actor();
     dispatch(&app, &actor, cli).await
+}
+
+async fn serve_cmd(app: App, port: Option<u16>, open_browser: bool) -> Result<(), i32> {
+    let addr = std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, port.unwrap_or(0)));
+    match taskboard_api::serve(app, addr, false).await {
+        Ok(bound) => {
+            let url = format!("http://127.0.0.1:{}", bound.port());
+            println!("{url}");
+            let _ = std::io::stdout().flush();
+            if open_browser {
+                let _ = open::that(&url);
+            }
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+        Err(taskboard_api::ApiError::Bind { .. }) if port.is_some() => {
+            eprintln!("error: port unavailable");
+            Err(1)
+        }
+        Err(err) => {
+            eprintln!("error: {err}");
+            Err(1)
+        }
+    }
 }
 
 async fn dispatch(app: &App, actor: &Actor, cli: Cli) -> Result<(), i32> {
@@ -88,7 +114,7 @@ async fn dispatch(app: &App, actor: &Actor, cli: Cli) -> Result<(), i32> {
             Ok(())
         }
         Command::Backup(cmd) => backup_cmd(app, json, cmd).await,
-        Command::Serve(_) => unreachable!("serve is handled before opening the database"),
+        Command::Serve(_) => unreachable!("serve is handled before dispatch"),
     }
 }
 

--- a/crates/cli/tests/cli_json.rs
+++ b/crates/cli/tests/cli_json.rs
@@ -53,15 +53,37 @@ fn failed_mutation_is_not_ok_true() {
 }
 
 #[test]
-fn serve_is_unavailable() {
-    let (mut cmd, _dir) = tb();
-    cmd.args(["serve"])
-        .assert()
-        .failure()
-        .code(1)
-        .stderr(predicate::str::contains(
-            "error: tb serve is not available in this build",
-        ));
+fn serve_prints_localhost_url() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = assert_cmd::cargo::cargo_bin("taskboard");
+    let mut child = std::process::Command::new(bin)
+        .args(["serve"])
+        .env("TASKBOARD_DATA_DIR", dir.path())
+        .env("HTTP_PROXY", "")
+        .env("HTTPS_PROXY", "")
+        .env("http_proxy", "")
+        .env("https_proxy", "")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let mut reader = std::io::BufReader::new(stdout);
+        let _ = std::io::BufRead::read_line(&mut reader, &mut line);
+        let _ = tx.send(line);
+    });
+    let line = rx
+        .recv_timeout(std::time::Duration::from_secs(15))
+        .expect("serve should print a URL");
+    assert!(
+        line.contains("http://127.0.0.1:"),
+        "expected localhost URL, got {line:?}"
+    );
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #15

Exposes application use cases over localhost HTTP. `tb serve` binds `127.0.0.1`, prints the URL, and keeps the Axum server running. Routes match detailed design section 8. JSON is camelCase; `If-Match` maps to optional revision; actor is `web` / `local-web`.

PATCH `beforeDisplayId: null` moves a card to the end of its column. Combined PATCH chains If-Match using each returned revision.

## Verification

- `cargo test -p taskboard-api -- --test-threads=1` — 13 passed (security + routes + If-Match unit tests)
- `cargo test -p taskboard-cli -- --test-threads=1` — 9 passed, including `serve_prints_localhost_url`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

