### PR TITLE
feat: add Native Glass board and inspector UI

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@taskboard/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@taskboard/client": "workspace:*",
+    "@taskboard/types": "workspace:*",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^18.3.24",
+    "@types/react-dom": "^18.3.7",
+    "jsdom": "^26.1.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/ui/src/Board.module.css
+++ b/packages/ui/src/Board.module.css
@@ -1,0 +1,69 @@
+.board {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-width: 0;
+  background: var(--board-bg);
+  color: var(--board-fg);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.25rem 0.15rem 0;
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(240px, 1fr));
+  gap: 0.85rem;
+  min-width: 1100px;
+  overflow-x: auto;
+  padding-bottom: 1rem;
+}
+
+.column {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 12rem;
+  border-radius: 16px;
+  padding: 0.75rem;
+  background: color-mix(in srgb, #fff 55%, var(--board-bg));
+  border: 1px solid var(--card-border);
+}
+
+.columnCurrent {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 650;
+}
+
+.count {
+  color: color-mix(in srgb, var(--board-fg) 50%, transparent);
+  font-variant-numeric: tabular-nums;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  min-height: 4.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.slot {
+  flex: 1;
+  min-height: 4.5rem;
+  border: 1px dashed color-mix(in srgb, var(--board-fg) 18%, transparent);
+  border-radius: 12px;
+}

--- a/packages/ui/src/Board.test.tsx
+++ b/packages/ui/src/Board.test.tsx
@@ -1,9 +1,25 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { fakeTransport } from "./fakeTransport";
 import { TaskboardApp } from "./index";
+
+vi.mock("./Board", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./Board")>();
+  return {
+    ...actual,
+    Board: (props: ComponentProps<typeof actual.Board>) => (
+      <>
+        <actual.Board {...props} />
+        <button type="button" onClick={() => props.onReorder("TASK-1", "TASK-2")}>
+          Test reorder
+        </button>
+      </>
+    ),
+  };
+});
 
 describe("Board", () => {
   it("shows empty copy when there are no projects", async () => {
@@ -83,6 +99,33 @@ describe("Board", () => {
         await vi.advanceTimersByTimeAsync(400);
       });
       expect(transport.taskNoteSet).toHaveBeenCalledWith("TASK-1", "updated note", titleRevision);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("taskNoteSet after reorder uses the updated revision", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "First", column: "todo" });
+    await transport.taskCreate(project.slug, { title: "Second", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByText("First"));
+    await screen.findByLabelText("Note");
+
+    await userEvent.click(screen.getByRole("button", { name: "Test reorder" }));
+    await waitFor(() => expect(transport.taskReorder).toHaveBeenCalled());
+    const afterReorder = await vi.mocked(transport.taskReorder).mock.results.at(-1)!.value;
+    const reorderRevision = afterReorder.revision;
+    expect(reorderRevision).toBeGreaterThan(1);
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByLabelText("Note"), { target: { value: "after reorder" } });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      expect(transport.taskNoteSet).toHaveBeenCalledWith("TASK-1", "after reorder", reorderRevision);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/ui/src/Board.test.tsx
+++ b/packages/ui/src/Board.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { fakeTransport } from "./fakeTransport";
 import { TaskboardApp } from "./index";
@@ -58,5 +58,33 @@ describe("Board", () => {
     await userEvent.keyboard("alpha");
     expect(screen.getByText("Alpha task")).toBeTruthy();
     expect(screen.queryByText("Beta item")).toBeNull();
+  });
+
+  it("taskNoteSet after title commit uses the updated revision", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Old title", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByText("Old title"));
+
+    const titleInput = await screen.findByLabelText("Title");
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, "New title");
+    fireEvent.blur(titleInput);
+    await waitFor(() => expect(transport.taskUpdate).toHaveBeenCalled());
+    const afterTitle = await vi.mocked(transport.taskUpdate).mock.results.at(-1)!.value;
+    const titleRevision = afterTitle.revision;
+    expect(titleRevision).toBeGreaterThan(1);
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByLabelText("Note"), { target: { value: "updated note" } });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      expect(transport.taskNoteSet).toHaveBeenCalledWith("TASK-1", "updated note", titleRevision);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/ui/src/Board.test.tsx
+++ b/packages/ui/src/Board.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { fakeTransport } from "./fakeTransport";
+import { TaskboardApp } from "./index";
+
+describe("Board", () => {
+  it("shows empty copy when there are no projects", async () => {
+    render(<TaskboardApp transport={fakeTransport()} />);
+    expect(await screen.findByText("Create a project to start a board")).toBeTruthy();
+  });
+
+  it("New project calls projectAdd with Untitled", async () => {
+    const transport = fakeTransport();
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(screen.getByRole("button", { name: "New project" }));
+    expect(transport.projectAdd).toHaveBeenCalledWith({ name: "Untitled" });
+  });
+
+  it("renders four columns with exact aria-labels after a project exists", async () => {
+    const transport = fakeTransport();
+    await transport.projectAdd({ name: "Untitled" });
+    render(<TaskboardApp transport={transport} />);
+    expect(await screen.findByRole("list", { name: "Todo" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "In Progress" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "In Review" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Done" })).toBeTruthy();
+  });
+
+  it("loads first project tasks on mount as listitems", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Alpha" });
+    await transport.taskCreate(project.slug, { title: "Ship board", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    expect(transport.projectList).toHaveBeenCalledWith(false);
+    expect(await screen.findByText("Ship board")).toBeTruthy();
+    expect(screen.getByText("TASK-1")).toBeTruthy();
+    expect(screen.getByRole("listitem", { name: /Ship board/ })).toBeTruthy();
+    await waitFor(() => expect(transport.taskList).toHaveBeenCalledWith(project.slug));
+  });
+
+  it("shows inspector empty copy until a card is selected", async () => {
+    const transport = fakeTransport();
+    await transport.projectAdd({ name: "Untitled" });
+    render(<TaskboardApp transport={transport} />);
+    expect(await screen.findByText("Select a card")).toBeTruthy();
+  });
+
+  it("filters cards by title substring", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Alpha task", column: "todo" });
+    await transport.taskCreate(project.slug, { title: "Beta item", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    expect(await screen.findByText("Alpha task")).toBeTruthy();
+    await userEvent.keyboard("/");
+    await userEvent.keyboard("alpha");
+    expect(screen.getByText("Alpha task")).toBeTruthy();
+    expect(screen.queryByText("Beta item")).toBeNull();
+  });
+});

--- a/packages/ui/src/Board.tsx
+++ b/packages/ui/src/Board.tsx
@@ -1,0 +1,134 @@
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { Column, TaskSummary } from "@taskboard/types";
+
+import type { ReactNode, Ref } from "react";
+
+import { Card } from "./Card";
+import { COLUMNS, COLUMN_IDS } from "./columns";
+import { Search } from "./Search";
+import styles from "./Board.module.css";
+
+export function Board(props: {
+  tasks: TaskSummary[];
+  selectedId: string | null;
+  currentColumn: Column;
+  query: string;
+  searchRef?: Ref<HTMLInputElement>;
+  onQueryChange: (value: string) => void;
+  onSelectCard: (displayId: string) => void;
+  onMove: (displayId: string, column: Column) => void;
+  onReorder: (displayId: string, beforeId: string) => void;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+  const q = props.query;
+  const visible = q
+    ? props.tasks.filter((t) => t.title.toLowerCase().includes(q.toLowerCase()))
+    : props.tasks;
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over) return;
+    const id = String(active.id);
+    const overId = String(over.id);
+    if (id === overId) return;
+    if ((COLUMN_IDS as string[]).includes(overId)) {
+      props.onMove(id, overId as Column);
+      return;
+    }
+    props.onReorder(id, overId);
+  }
+
+  return (
+    <section className={styles.board}>
+      <div className={styles.toolbar}>
+        <Search value={props.query} onChange={props.onQueryChange} inputRef={props.searchRef} />
+      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <div className={styles.columns}>
+          {COLUMNS.map((col) => {
+            const columnTasks = visible.filter((t) => t.column === col.id);
+            return (
+              <ColumnDrop
+                key={col.id}
+                column={col.id}
+                label={col.label}
+                count={columnTasks.length}
+                current={props.currentColumn === col.id}
+              >
+                <SortableContext
+                  items={columnTasks.map((t) => t.displayId)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {columnTasks.map((task) => (
+                    <SortableCard
+                      key={task.displayId}
+                      task={task}
+                      selected={props.selectedId === task.displayId}
+                      onSelect={() => props.onSelectCard(task.displayId)}
+                    />
+                  ))}
+                  {columnTasks.length === 0 ? <div className={styles.slot} /> : null}
+                </SortableContext>
+              </ColumnDrop>
+            );
+          })}
+        </div>
+      </DndContext>
+    </section>
+  );
+}
+
+function ColumnDrop(props: {
+  column: Column;
+  label: string;
+  count: number;
+  current: boolean;
+  children: ReactNode;
+}) {
+  const { setNodeRef } = useDroppable({ id: props.column });
+  return (
+    <div className={`${styles.column} ${props.current ? styles.columnCurrent : ""}`}>
+      <h2 className={styles.header}>
+        {props.label}
+        <span className={styles.count}>{props.count}</span>
+      </h2>
+      <div ref={setNodeRef} role="list" aria-label={props.label} className={styles.list}>
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+function SortableCard(props: {
+  task: TaskSummary;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: props.task.displayId,
+  });
+  return (
+    <Card
+      ref={setNodeRef}
+      task={props.task}
+      selected={props.selected}
+      grabbed={isDragging}
+      onClick={props.onSelect}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      {...attributes}
+      {...listeners}
+    />
+  );
+}

--- a/packages/ui/src/Board.tsx
+++ b/packages/ui/src/Board.tsx
@@ -13,8 +13,9 @@ import type { Column, TaskSummary } from "@taskboard/types";
 
 import type { ReactNode, Ref } from "react";
 
+import { resolveDragEnd } from "./boardDrag";
 import { Card } from "./Card";
-import { COLUMNS, COLUMN_IDS } from "./columns";
+import { COLUMNS } from "./columns";
 import { Search } from "./Search";
 import styles from "./Board.module.css";
 
@@ -38,16 +39,13 @@ export function Board(props: {
     : props.tasks;
 
   function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event;
-    if (!over) return;
-    const id = String(active.id);
-    const overId = String(over.id);
-    if (id === overId) return;
-    if ((COLUMN_IDS as string[]).includes(overId)) {
-      props.onMove(id, overId as Column);
-      return;
-    }
-    props.onReorder(id, overId);
+    const action = resolveDragEnd(
+      String(event.active.id),
+      event.over ? String(event.over.id) : null,
+      props.tasks,
+    );
+    if (action.kind === "move") props.onMove(action.displayId, action.column);
+    if (action.kind === "reorder") props.onReorder(action.displayId, action.beforeId);
   }
 
   return (

--- a/packages/ui/src/Card.module.css
+++ b/packages/ui/src/Card.module.css
@@ -1,0 +1,86 @@
+.card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto auto;
+  gap: 0.2rem 0.5rem;
+  padding: 0.7rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  backdrop-filter: blur(16px);
+  color: var(--board-fg);
+  cursor: grab;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.7) inset, 0 8px 20px rgba(28, 27, 34, 0.04);
+}
+
+.card[aria-selected="true"] {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.title {
+  grid-column: 1;
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.displayId {
+  grid-column: 1;
+  color: color-mix(in srgb, var(--board-fg) 55%, transparent);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+}
+
+.meta {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--urgent);
+}
+
+.badge {
+  font-size: 0.65rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  padding: 0.12rem 0.4rem;
+  border-radius: 999px;
+  color: #fff;
+}
+
+.waiting {
+  background: var(--waiting);
+}
+
+.running {
+  background: var(--running);
+}
+
+.failed {
+  background: var(--failed);
+}
+
+.completed {
+  background: var(--completed);
+}
+
+.runMessage {
+  grid-column: 1 / -1;
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--board-fg) 62%, transparent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/packages/ui/src/Card.test.tsx
+++ b/packages/ui/src/Card.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Card } from "./Card";
+import { summary } from "./summary";
+
+describe("Card", () => {
+  it("shows running badge and hides idle badge", () => {
+    const { getByText, queryByText, rerender } = render(
+      <Card task={summary({ displayStatus: "idle" })} selected={false} />,
+    );
+    expect(queryByText("Running")).toBeNull();
+    rerender(<Card task={summary({ displayStatus: "running" })} selected={false} />);
+    expect(getByText("Running")).toBeTruthy();
+  });
+
+  it("shows waiting, failed, and completed badges", () => {
+    const { getByText, queryByText, rerender } = render(
+      <Card task={summary({ displayStatus: "waiting" })} selected={false} />,
+    );
+    expect(getByText("Waiting")).toBeTruthy();
+    expect(queryByText("Running")).toBeNull();
+    rerender(<Card task={summary({ displayStatus: "failed" })} selected={false} />);
+    expect(getByText("Failed")).toBeTruthy();
+    rerender(<Card task={summary({ displayStatus: "completed" })} selected={false} />);
+    expect(getByText("Done")).toBeTruthy();
+    expect(queryByText("Completed")).toBeNull();
+  });
+
+  it("renders title, display id, listitem role, and urgent pip", () => {
+    const { getByText, getByRole, queryByLabelText, rerender } = render(
+      <Card task={summary({ title: "Fix login", displayId: "TASK-7" })} selected={false} />,
+    );
+    expect(getByText("Fix login")).toBeTruthy();
+    expect(getByText("TASK-7")).toBeTruthy();
+    expect(getByRole("listitem")).toBeTruthy();
+    expect(queryByLabelText("Urgent")).toBeNull();
+    rerender(
+      <Card task={summary({ title: "Fix login", displayId: "TASK-7", urgent: true })} selected={false} />,
+    );
+    expect(getByRole("listitem", { name: /Urgent/ })).toBeTruthy();
+    expect(getByRole("listitem").querySelector('[aria-label="Urgent"]')).toBeTruthy();
+  });
+});

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,0 +1,45 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import type { TaskSummary } from "@taskboard/types";
+
+import { BADGE_LABEL } from "./columns";
+import styles from "./Card.module.css";
+
+export type CardProps = {
+  task: TaskSummary;
+  selected: boolean;
+  grabbed?: boolean;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { task, selected, grabbed, className, ...rest },
+  ref,
+) {
+  const badge = BADGE_LABEL[task.displayStatus];
+  const showMessage =
+    (task.displayStatus === "running" || task.displayStatus === "waiting") && task.runMessage;
+  const label = [task.title, task.displayId, task.urgent ? "Urgent" : null, badge]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      ref={ref}
+      className={[styles.card, className].filter(Boolean).join(" ")}
+      {...rest}
+      role="listitem"
+      aria-label={label}
+      aria-selected={selected}
+      aria-grabbed={grabbed || undefined}
+    >
+      <span className={styles.title}>{task.title}</span>
+      <span className={styles.displayId}>{task.displayId}</span>
+      <span className={styles.meta}>
+        {task.urgent ? <span className={styles.pip} aria-label="Urgent" /> : null}
+        {badge ? (
+          <span className={`${styles.badge} ${styles[task.displayStatus]}`}>{badge}</span>
+        ) : null}
+      </span>
+      {showMessage ? <span className={styles.runMessage}>{task.runMessage}</span> : null}
+    </div>
+  );
+});

--- a/packages/ui/src/EmptyState.module.css
+++ b/packages/ui/src/EmptyState.module.css
@@ -1,0 +1,8 @@
+.empty {
+  margin: 0;
+  padding: 0.75rem 0.25rem;
+  color: inherit;
+  opacity: 0.72;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}

--- a/packages/ui/src/EmptyState.tsx
+++ b/packages/ui/src/EmptyState.tsx
@@ -1,0 +1,7 @@
+import type { ReactNode } from "react";
+
+import styles from "./EmptyState.module.css";
+
+export function EmptyState({ children }: { children: ReactNode }) {
+  return <p className={styles.empty}>{children}</p>;
+}

--- a/packages/ui/src/Inspector.module.css
+++ b/packages/ui/src/Inspector.module.css
@@ -1,0 +1,79 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  height: 100%;
+  padding: 1rem 1rem 1.25rem;
+  background: color-mix(in srgb, #fff 70%, var(--board-bg));
+  border-left: 1px solid var(--card-border);
+  color: var(--board-fg);
+  overflow: auto;
+}
+
+.empty {
+  color: color-mix(in srgb, var(--board-fg) 55%, transparent);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.field input,
+.field select,
+.field textarea {
+  font: inherit;
+  font-weight: 400;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  color: var(--board-fg);
+  padding: 0.4rem 0.5rem;
+}
+
+.note {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.displayId {
+  margin: 0;
+  font-size: 0.8rem;
+  color: color-mix(in srgb, var(--board-fg) 55%, transparent);
+}
+
+.switch {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+}
+
+.list {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.8rem;
+}
+
+.heading {
+  margin: 0 0 0.35rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--board-fg) 50%, transparent);
+}
+
+.delete {
+  margin-top: auto;
+  border: 0;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--urgent) 12%, transparent);
+  color: var(--urgent);
+  font: inherit;
+  font-weight: 600;
+  padding: 0.45rem 0.6rem;
+  cursor: pointer;
+}

--- a/packages/ui/src/Inspector.tsx
+++ b/packages/ui/src/Inspector.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState, type Ref } from "react";
+import type { Column, TaskDetail } from "@taskboard/types";
+
+import { COLUMNS } from "./columns";
+import { EmptyState } from "./EmptyState";
+import styles from "./Inspector.module.css";
+
+export function Inspector(props: {
+  task: TaskDetail | null;
+  open: boolean;
+  titleRef?: Ref<HTMLInputElement>;
+  onTitleCommit: (title: string) => void;
+  onColumnChange: (column: Column) => void;
+  onUrgentChange: (urgent: boolean) => void;
+  onNoteChange: (markdown: string) => void;
+  onDelete: () => void;
+}) {
+  const [title, setTitle] = useState(props.task?.title ?? "");
+  const [note, setNote] = useState(props.task?.noteMarkdown ?? "");
+  const lastId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!props.task) {
+      lastId.current = null;
+      setTitle("");
+      setNote("");
+      return;
+    }
+    if (lastId.current !== props.task.displayId) {
+      lastId.current = props.task.displayId;
+      setTitle(props.task.title);
+      setNote(props.task.noteMarkdown);
+    }
+  }, [props.task]);
+
+  useEffect(() => {
+    if (!props.task) return;
+    if (note === props.task.noteMarkdown) return;
+    const handle = window.setTimeout(() => {
+      props.onNoteChange(note);
+    }, 400);
+    return () => window.clearTimeout(handle);
+  }, [note, props.task, props.onNoteChange]);
+
+  if (!props.open) return null;
+
+  if (!props.task) {
+    return (
+      <aside className={styles.panel}>
+        <div className={styles.empty}>
+          <EmptyState>Select a card</EmptyState>
+        </div>
+      </aside>
+    );
+  }
+
+  const runs = [...props.task.runs].sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
+  const activities = [...props.task.recentActivities].sort((a, b) => b.sequence - a.sequence);
+
+  return (
+    <aside className={styles.panel}>
+      <label className={styles.field}>
+        Title
+        <input
+          ref={props.titleRef}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onBlur={() => props.onTitleCommit(title)}
+        />
+      </label>
+      <p className={styles.displayId}>{props.task.displayId}</p>
+      <label className={styles.field}>
+        Column
+        <select
+          value={props.task.column}
+          onChange={(e) => props.onColumnChange(e.target.value as Column)}
+        >
+          {COLUMNS.map((col) => (
+            <option key={col.id} value={col.id}>
+              {col.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.switch}>
+        <input
+          type="checkbox"
+          checked={props.task.urgent}
+          onChange={(e) => props.onUrgentChange(e.target.checked)}
+        />
+        Urgent
+      </label>
+      <label className={styles.field}>
+        Note
+        <textarea
+          className={styles.note}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+      </label>
+      <div>
+        <h3 className={styles.heading}>Links</h3>
+        <ul className={styles.list}>
+          {props.task.links.map((link) => (
+            <li key={link.id}>{link.value}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className={styles.heading}>Runs</h3>
+        <ul className={styles.list}>
+          {runs.map((run) => (
+            <li key={run.id}>
+              {run.displayId} {run.status}
+              {run.message ? ` — ${run.message}` : ""}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className={styles.heading}>Activity</h3>
+        <ul className={styles.list}>
+          {activities.map((item) => (
+            <li key={item.id}>
+              {item.operation} · {item.actorLabel}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <button type="button" className={styles.delete} onClick={props.onDelete}>
+        Delete
+      </button>
+    </aside>
+  );
+}

--- a/packages/ui/src/Search.module.css
+++ b/packages/ui/src/Search.module.css
@@ -1,0 +1,10 @@
+.input {
+  width: 100%;
+  max-width: 28rem;
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  background: var(--card-bg);
+  color: var(--board-fg);
+  padding: 0.45rem 0.75rem;
+  font: inherit;
+}

--- a/packages/ui/src/Search.tsx
+++ b/packages/ui/src/Search.tsx
@@ -1,0 +1,21 @@
+import type { Ref } from "react";
+
+import styles from "./Search.module.css";
+
+export function Search(props: {
+  value: string;
+  onChange: (value: string) => void;
+  inputRef?: Ref<HTMLInputElement>;
+}) {
+  return (
+    <input
+      ref={props.inputRef}
+      className={styles.input}
+      type="search"
+      aria-label="Search"
+      placeholder="Search"
+      value={props.value}
+      onChange={(e) => props.onChange(e.target.value)}
+    />
+  );
+}

--- a/packages/ui/src/Sidebar.module.css
+++ b/packages/ui/src/Sidebar.module.css
@@ -1,0 +1,103 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  height: 100%;
+  padding: 1rem 0.9rem 1.1rem;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.brand {
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--sidebar-muted);
+}
+
+.newProject {
+  border: 0;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.project {
+  width: 100%;
+  text-align: left;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--sidebar-fg);
+  font: inherit;
+  font-size: 0.88rem;
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+}
+
+.project[aria-current="true"] {
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
+}
+
+.selectedName {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.note {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--sidebar-muted);
+}
+
+.note textarea {
+  min-height: 6.5rem;
+  resize: vertical;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, #fff 12%, transparent);
+  background: color-mix(in srgb, #fff 6%, transparent);
+  color: var(--sidebar-fg);
+  font: inherit;
+  padding: 0.5rem;
+}
+
+.toggle,
+.trash {
+  border: 0;
+  background: transparent;
+  color: var(--sidebar-muted);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-align: left;
+  padding: 0.25rem 0;
+}
+
+.toggle[aria-pressed="true"] {
+  color: var(--accent-2);
+}

--- a/packages/ui/src/Sidebar.tsx
+++ b/packages/ui/src/Sidebar.tsx
@@ -1,0 +1,72 @@
+import type { Project } from "@taskboard/types";
+
+import { EmptyState } from "./EmptyState";
+import styles from "./Sidebar.module.css";
+
+export function Sidebar(props: {
+  projects: Project[];
+  selectedSlug: string | null;
+  includeArchived: boolean;
+  projectNote: string;
+  onNewProject: () => void;
+  onSelectProject: (slug: string) => void;
+  onToggleArchived: () => void;
+  onProjectNoteChange: (markdown: string) => void;
+  onTrash?: () => void;
+}) {
+  return (
+    <aside className={styles.sidebar}>
+      <div className={styles.header}>
+        <span className={styles.brand}>Projects</span>
+        <button type="button" className={styles.newProject} onClick={props.onNewProject}>
+          New project
+        </button>
+      </div>
+      {props.projects.length === 0 ? (
+        <EmptyState>Create a project to start a board</EmptyState>
+      ) : (
+        <ul className={styles.list}>
+          {props.projects.map((project) => (
+            <li key={project.id}>
+              <button
+                type="button"
+                className={styles.project}
+                aria-current={project.slug === props.selectedSlug}
+                onClick={() => props.onSelectProject(project.slug)}
+              >
+                {project.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {props.selectedSlug ? (
+        <>
+          <p className={styles.selectedName}>
+            {props.projects.find((p) => p.slug === props.selectedSlug)?.name}
+          </p>
+          <label className={styles.note}>
+            Project note
+            <textarea
+              value={props.projectNote}
+              onChange={(e) => props.onProjectNoteChange(e.target.value)}
+            />
+          </label>
+        </>
+      ) : null}
+      <button
+        type="button"
+        className={styles.toggle}
+        aria-pressed={props.includeArchived}
+        onClick={props.onToggleArchived}
+      >
+        Archived
+      </button>
+      {props.onTrash ? (
+        <button type="button" className={styles.trash} onClick={props.onTrash}>
+          Trash
+        </button>
+      ) : null}
+    </aside>
+  );
+}

--- a/packages/ui/src/TaskboardApp.module.css
+++ b/packages/ui/src/TaskboardApp.module.css
@@ -1,0 +1,19 @@
+.app {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) minmax(320px, 420px);
+  min-height: 100vh;
+  font-family: "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  background: var(--board-bg);
+}
+
+.collapsed {
+  grid-template-columns: 240px minmax(0, 1fr);
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 0.9rem 1rem 1.25rem;
+  overflow: auto;
+}

--- a/packages/ui/src/TaskboardApp.tsx
+++ b/packages/ui/src/TaskboardApp.tsx
@@ -334,7 +334,10 @@ export function TaskboardApp(props: { transport: Transport }) {
   const onReorder = useCallback(
     async (displayId: string, beforeId: string) => {
       const task = tasksRef.current.find((t) => t.displayId === displayId);
-      await transport.taskReorder(displayId, beforeId, task?.revision);
+      const updated = await transport.taskReorder(displayId, beforeId, task?.revision);
+      if (selectedIdRef.current === displayId) {
+        applyDetail(updated);
+      }
       const project = selectedProjectRef.current;
       if (project) await refreshTasks(project.slug);
     },

--- a/packages/ui/src/TaskboardApp.tsx
+++ b/packages/ui/src/TaskboardApp.tsx
@@ -1,0 +1,462 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Transport } from "@taskboard/client";
+import type { Column, Project, TaskDetail, TaskSummary } from "@taskboard/types";
+
+import { Board } from "./Board";
+import { Inspector } from "./Inspector";
+import { Sidebar } from "./Sidebar";
+import { COLUMN_IDS, neighborColumn } from "./columns";
+import styles from "./TaskboardApp.module.css";
+import "./theme.css";
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+}
+
+export function TaskboardApp(props: { transport: Transport }) {
+  const { transport } = props;
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const [tasks, setTasks] = useState<TaskSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<TaskDetail | null>(null);
+  const [currentColumn, setCurrentColumn] = useState<Column>("todo");
+  const [query, setQuery] = useState("");
+  const [inspectorOpen, setInspectorOpen] = useState(true);
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [projectNote, setProjectNote] = useState("");
+
+  const searchRef = useRef<HTMLInputElement>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const pendingProject = useRef<Promise<Project> | null>(null);
+  const selectedProjectRef = useRef<Project | null>(null);
+  const selectedIdRef = useRef<string | null>(null);
+  const tasksRef = useRef<TaskSummary[]>([]);
+  const currentColumnRef = useRef<Column>("todo");
+  const queryRef = useRef("");
+  const inspectorOpenRef = useRef(true);
+  const projectsRef = useRef<Project[]>([]);
+  const detailRef = useRef<TaskDetail | null>(null);
+  const includeArchivedRef = useRef(false);
+
+  selectedProjectRef.current = selectedProject;
+  selectedIdRef.current = selectedId;
+  tasksRef.current = tasks;
+  currentColumnRef.current = currentColumn;
+  queryRef.current = query;
+  inspectorOpenRef.current = inspectorOpen;
+  projectsRef.current = projects;
+  detailRef.current = detail;
+  includeArchivedRef.current = includeArchived;
+
+  const refreshTasks = useCallback(
+    async (slug: string) => {
+      const list = await transport.taskList(slug);
+      setTasks(list);
+      tasksRef.current = list;
+      return list;
+    },
+    [transport],
+  );
+
+  const applyProject = useCallback(
+    async (project: Project) => {
+      selectedProjectRef.current = project;
+      setSelectedProject(project);
+      setProjectNote(project.noteMarkdown);
+      setSelectedId(null);
+      selectedIdRef.current = null;
+      setDetail(null);
+      setInspectorOpen(true);
+      inspectorOpenRef.current = true;
+      setCurrentColumn("todo");
+      currentColumnRef.current = "todo";
+      await refreshTasks(project.slug);
+    },
+    [refreshTasks],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const list = await transport.projectList(false);
+      if (cancelled) return;
+      setProjects(list);
+      if (list[0]) await applyProject(list[0]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [transport, applyProject]);
+
+  const addProject = useCallback(() => {
+    const promise = (async () => {
+      const project = await transport.projectAdd({ name: "Untitled" });
+      selectedProjectRef.current = project;
+      selectedIdRef.current = null;
+      setSelectedProject(project);
+      setSelectedId(null);
+      setDetail(null);
+      setInspectorOpen(true);
+      inspectorOpenRef.current = true;
+      setProjectNote(project.noteMarkdown);
+      setProjects((prev) => {
+        const next = prev.some((p) => p.id === project.id) ? prev : [...prev, project];
+        projectsRef.current = next;
+        return next;
+      });
+      await refreshTasks(project.slug);
+      return project;
+    })();
+    pendingProject.current = promise;
+    return promise;
+  }, [transport, refreshTasks]);
+
+  const selectCard = useCallback(
+    async (displayId: string) => {
+      const task = tasksRef.current.find((t) => t.displayId === displayId);
+      selectedIdRef.current = displayId;
+      setSelectedId(displayId);
+      setInspectorOpen(true);
+      inspectorOpenRef.current = true;
+      if (task) {
+        setCurrentColumn(task.column);
+        currentColumnRef.current = task.column;
+      }
+      const shown = await transport.taskShow(displayId);
+      setDetail(shown);
+      detailRef.current = shown;
+    },
+    [transport],
+  );
+
+  const createTask = useCallback(async () => {
+    if (pendingProject.current) {
+      await pendingProject.current;
+    }
+    const project = selectedProjectRef.current;
+    if (!project) return;
+    const created = await transport.taskCreate(project.slug, {
+      title: "Untitled",
+      column: currentColumnRef.current,
+    });
+    await refreshTasks(project.slug);
+    selectedIdRef.current = created.displayId;
+    setSelectedId(created.displayId);
+    setDetail(created);
+    detailRef.current = created;
+    setInspectorOpen(true);
+    inspectorOpenRef.current = true;
+  }, [transport, refreshTasks]);
+
+  const toggleUrgent = useCallback(async () => {
+    const id = selectedIdRef.current;
+    if (!id) return;
+    const task = tasksRef.current.find((t) => t.displayId === id);
+    const next = !(task?.urgent ?? detailRef.current?.urgent ?? false);
+    const updated = await transport.taskUrgent(id, next, task?.revision ?? detailRef.current?.revision);
+    setDetail(updated);
+    detailRef.current = updated;
+    const project = selectedProjectRef.current;
+    if (project) await refreshTasks(project.slug);
+  }, [transport, refreshTasks]);
+
+  const moveSelected = useCallback(
+    async (column: Column) => {
+      const id = selectedIdRef.current;
+      if (!id) {
+        setCurrentColumn(column);
+        currentColumnRef.current = column;
+        return;
+      }
+      const task = tasksRef.current.find((t) => t.displayId === id);
+      const updated = await transport.taskMove(id, column, task?.revision);
+      setDetail(updated);
+      detailRef.current = updated;
+      setCurrentColumn(column);
+      currentColumnRef.current = column;
+      const project = selectedProjectRef.current;
+      if (project) await refreshTasks(project.slug);
+    },
+    [transport, refreshTasks],
+  );
+
+  const selectInColumn = useCallback(
+    (dir: 1 | -1) => {
+      const col = currentColumnRef.current;
+      const q = queryRef.current;
+      const inCol = tasksRef.current.filter(
+        (t) => t.column === col && (!q || t.title.toLowerCase().includes(q.toLowerCase())),
+      );
+      if (inCol.length === 0) return;
+      const idx = inCol.findIndex((t) => t.displayId === selectedIdRef.current);
+      let nextIdx: number;
+      if (idx < 0) nextIdx = dir > 0 ? 0 : inCol.length - 1;
+      else nextIdx = Math.max(0, Math.min(inCol.length - 1, idx + dir));
+      const next = inCol[nextIdx];
+      if (next) void selectCard(next.displayId);
+    },
+    [selectCard],
+  );
+
+  const jumpColumn = useCallback((index: number) => {
+    const column = COLUMN_IDS[index];
+    if (!column) return;
+    setCurrentColumn(column);
+    currentColumnRef.current = column;
+  }, []);
+
+  const switchProject = useCallback(
+    (dir: -1 | 1) => {
+      const list = projectsRef.current;
+      const current = selectedProjectRef.current;
+      if (!current || list.length === 0) return;
+      const i = list.findIndex((p) => p.slug === current.slug);
+      const next = list[i + dir];
+      if (next) void applyProject(next);
+    },
+    [applyProject],
+  );
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isTypingTarget(e.target)) {
+        if (e.key === "Escape" && e.target === searchRef.current) {
+          setQuery("");
+          queryRef.current = "";
+          searchRef.current?.blur();
+        }
+        return;
+      }
+
+      if (e.key === "/") {
+        e.preventDefault();
+        searchRef.current?.focus();
+        return;
+      }
+      if (e.key === "Escape") {
+        if (queryRef.current) {
+          setQuery("");
+          queryRef.current = "";
+          return;
+        }
+        setInspectorOpen(false);
+        inspectorOpenRef.current = false;
+        return;
+      }
+      if (e.key === "Enter") {
+        const id = selectedIdRef.current;
+        if (id) {
+          setInspectorOpen(true);
+          inspectorOpenRef.current = true;
+          void selectCard(id);
+        }
+        return;
+      }
+      if (e.key === "p") {
+        e.preventDefault();
+        void addProject();
+        return;
+      }
+      if (e.key === "n") {
+        e.preventDefault();
+        void createTask();
+        return;
+      }
+      if (e.key === "u") {
+        e.preventDefault();
+        void toggleUrgent();
+        return;
+      }
+      if (e.key === "j") {
+        e.preventDefault();
+        selectInColumn(1);
+        return;
+      }
+      if (e.key === "k") {
+        e.preventDefault();
+        selectInColumn(-1);
+        return;
+      }
+      if (e.key === "h" || e.key === "l") {
+        e.preventDefault();
+        const dir = e.key === "l" ? 1 : -1;
+        const next = neighborColumn(currentColumnRef.current, dir);
+        if (!next) return;
+        if (selectedIdRef.current) void moveSelected(next);
+        else {
+          setCurrentColumn(next);
+          currentColumnRef.current = next;
+        }
+        return;
+      }
+      if (e.key >= "1" && e.key <= "4") {
+        e.preventDefault();
+        jumpColumn(Number(e.key) - 1);
+        return;
+      }
+      if (e.key === "[") {
+        e.preventDefault();
+        switchProject(-1);
+        return;
+      }
+      if (e.key === "]") {
+        e.preventDefault();
+        switchProject(1);
+        return;
+      }
+      if (e.key === "e") {
+        e.preventDefault();
+        setInspectorOpen(true);
+        inspectorOpenRef.current = true;
+        titleRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [addProject, createTask, jumpColumn, moveSelected, selectCard, selectInColumn, switchProject, toggleUrgent]);
+
+  const onMove = useCallback(
+    async (displayId: string, column: Column) => {
+      const task = tasksRef.current.find((t) => t.displayId === displayId);
+      const updated = await transport.taskMove(displayId, column, task?.revision);
+      if (selectedIdRef.current === displayId) {
+        setDetail(updated);
+        detailRef.current = updated;
+      }
+      const project = selectedProjectRef.current;
+      if (project) await refreshTasks(project.slug);
+    },
+    [transport, refreshTasks],
+  );
+
+  const onReorder = useCallback(
+    async (displayId: string, beforeId: string) => {
+      const task = tasksRef.current.find((t) => t.displayId === displayId);
+      await transport.taskReorder(displayId, beforeId, task?.revision);
+      const project = selectedProjectRef.current;
+      if (project) await refreshTasks(project.slug);
+    },
+    [transport, refreshTasks],
+  );
+
+  const onNoteChange = useCallback(
+    async (markdown: string) => {
+      const id = selectedIdRef.current;
+      if (!id) return;
+      const updated = await transport.taskNoteSet(id, markdown, detailRef.current?.revision);
+      setDetail(updated);
+      detailRef.current = updated;
+    },
+    [transport],
+  );
+
+  useEffect(() => {
+    const project = selectedProject;
+    if (!project) return;
+    if (projectNote === project.noteMarkdown) return;
+    const handle = window.setTimeout(() => {
+      void transport.projectNoteSet(project.slug, projectNote, project.revision).then((updated) => {
+        selectedProjectRef.current = updated;
+        setSelectedProject(updated);
+        setProjects((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+      });
+    }, 400);
+    return () => window.clearTimeout(handle);
+  }, [projectNote, selectedProject, transport]);
+
+  const onTitleCommit = useCallback(
+    async (title: string) => {
+      const id = selectedIdRef.current;
+      if (!id) return;
+      const updated = await transport.taskUpdate(id, { title }, detailRef.current?.revision);
+      setDetail(updated);
+      const project = selectedProjectRef.current;
+      if (project) await refreshTasks(project.slug);
+    },
+    [transport, refreshTasks],
+  );
+
+  const onDelete = useCallback(async () => {
+    const id = selectedIdRef.current;
+    if (!id) return;
+    await transport.taskDelete(id, detailRef.current?.revision);
+    setSelectedId(null);
+    selectedIdRef.current = null;
+    setDetail(null);
+    detailRef.current = null;
+    const project = selectedProjectRef.current;
+    if (project) await refreshTasks(project.slug);
+  }, [transport, refreshTasks]);
+
+  const toggleArchived = useCallback(async () => {
+    const next = !includeArchivedRef.current;
+    includeArchivedRef.current = next;
+    setIncludeArchived(next);
+    const list = await transport.projectList(next);
+    setProjects(list);
+    if (list[0]) await applyProject(list[0]);
+    else {
+      setSelectedProject(null);
+      selectedProjectRef.current = null;
+      setTasks([]);
+    }
+  }, [transport, applyProject]);
+
+  return (
+    <div className={`${styles.app} ${inspectorOpen ? "" : styles.collapsed}`}>
+      <Sidebar
+        projects={projects}
+        selectedSlug={selectedProject?.slug ?? null}
+        includeArchived={includeArchived}
+        projectNote={projectNote}
+        onNewProject={() => void addProject()}
+        onSelectProject={(slug) => {
+          const project = projectsRef.current.find((p) => p.slug === slug);
+          if (project) void applyProject(project);
+        }}
+        onToggleArchived={() => void toggleArchived()}
+        onProjectNoteChange={setProjectNote}
+        onTrash={() => void transport.trashList()}
+      />
+      <main className={styles.main}>
+        {selectedProject ? (
+          <Board
+            tasks={tasks}
+            selectedId={selectedId}
+            currentColumn={currentColumn}
+            query={query}
+            searchRef={searchRef}
+            onQueryChange={(value) => {
+              setQuery(value);
+              queryRef.current = value;
+            }}
+            onSelectCard={(id) => void selectCard(id)}
+            onMove={(id, column) => void onMove(id, column)}
+            onReorder={(id, beforeId) => void onReorder(id, beforeId)}
+          />
+        ) : null}
+      </main>
+      <Inspector
+        task={detail}
+        open={inspectorOpen}
+        titleRef={titleRef}
+        onTitleCommit={(title) => void onTitleCommit(title)}
+        onColumnChange={(column) => void moveSelected(column)}
+        onUrgentChange={(urgent) => {
+          const id = selectedIdRef.current;
+          if (!id) return;
+          void transport.taskUrgent(id, urgent, detailRef.current?.revision).then(async (updated) => {
+            setDetail(updated);
+            const project = selectedProjectRef.current;
+            if (project) await refreshTasks(project.slug);
+          });
+        }}
+        onNoteChange={onNoteChange}
+        onDelete={() => void onDelete()}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/TaskboardApp.tsx
+++ b/packages/ui/src/TaskboardApp.tsx
@@ -48,8 +48,12 @@ export function TaskboardApp(props: { transport: Transport }) {
   queryRef.current = query;
   inspectorOpenRef.current = inspectorOpen;
   projectsRef.current = projects;
-  detailRef.current = detail;
   includeArchivedRef.current = includeArchived;
+
+  const applyDetail = (updated: TaskDetail | null) => {
+    detailRef.current = updated;
+    setDetail(updated);
+  };
 
   const refreshTasks = useCallback(
     async (slug: string) => {
@@ -68,7 +72,7 @@ export function TaskboardApp(props: { transport: Transport }) {
       setProjectNote(project.noteMarkdown);
       setSelectedId(null);
       selectedIdRef.current = null;
-      setDetail(null);
+      applyDetail(null);
       setInspectorOpen(true);
       inspectorOpenRef.current = true;
       setCurrentColumn("todo");
@@ -98,7 +102,7 @@ export function TaskboardApp(props: { transport: Transport }) {
       selectedIdRef.current = null;
       setSelectedProject(project);
       setSelectedId(null);
-      setDetail(null);
+      applyDetail(null);
       setInspectorOpen(true);
       inspectorOpenRef.current = true;
       setProjectNote(project.noteMarkdown);
@@ -126,8 +130,7 @@ export function TaskboardApp(props: { transport: Transport }) {
         currentColumnRef.current = task.column;
       }
       const shown = await transport.taskShow(displayId);
-      setDetail(shown);
-      detailRef.current = shown;
+      applyDetail(shown);
     },
     [transport],
   );
@@ -145,8 +148,7 @@ export function TaskboardApp(props: { transport: Transport }) {
     await refreshTasks(project.slug);
     selectedIdRef.current = created.displayId;
     setSelectedId(created.displayId);
-    setDetail(created);
-    detailRef.current = created;
+    applyDetail(created);
     setInspectorOpen(true);
     inspectorOpenRef.current = true;
   }, [transport, refreshTasks]);
@@ -157,8 +159,7 @@ export function TaskboardApp(props: { transport: Transport }) {
     const task = tasksRef.current.find((t) => t.displayId === id);
     const next = !(task?.urgent ?? detailRef.current?.urgent ?? false);
     const updated = await transport.taskUrgent(id, next, task?.revision ?? detailRef.current?.revision);
-    setDetail(updated);
-    detailRef.current = updated;
+    applyDetail(updated);
     const project = selectedProjectRef.current;
     if (project) await refreshTasks(project.slug);
   }, [transport, refreshTasks]);
@@ -173,8 +174,7 @@ export function TaskboardApp(props: { transport: Transport }) {
       }
       const task = tasksRef.current.find((t) => t.displayId === id);
       const updated = await transport.taskMove(id, column, task?.revision);
-      setDetail(updated);
-      detailRef.current = updated;
+      applyDetail(updated);
       setCurrentColumn(column);
       currentColumnRef.current = column;
       const project = selectedProjectRef.current;
@@ -323,8 +323,7 @@ export function TaskboardApp(props: { transport: Transport }) {
       const task = tasksRef.current.find((t) => t.displayId === displayId);
       const updated = await transport.taskMove(displayId, column, task?.revision);
       if (selectedIdRef.current === displayId) {
-        setDetail(updated);
-        detailRef.current = updated;
+        applyDetail(updated);
       }
       const project = selectedProjectRef.current;
       if (project) await refreshTasks(project.slug);
@@ -347,8 +346,7 @@ export function TaskboardApp(props: { transport: Transport }) {
       const id = selectedIdRef.current;
       if (!id) return;
       const updated = await transport.taskNoteSet(id, markdown, detailRef.current?.revision);
-      setDetail(updated);
-      detailRef.current = updated;
+      applyDetail(updated);
     },
     [transport],
   );
@@ -372,7 +370,7 @@ export function TaskboardApp(props: { transport: Transport }) {
       const id = selectedIdRef.current;
       if (!id) return;
       const updated = await transport.taskUpdate(id, { title }, detailRef.current?.revision);
-      setDetail(updated);
+      applyDetail(updated);
       const project = selectedProjectRef.current;
       if (project) await refreshTasks(project.slug);
     },
@@ -385,8 +383,7 @@ export function TaskboardApp(props: { transport: Transport }) {
     await transport.taskDelete(id, detailRef.current?.revision);
     setSelectedId(null);
     selectedIdRef.current = null;
-    setDetail(null);
-    detailRef.current = null;
+    applyDetail(null);
     const project = selectedProjectRef.current;
     if (project) await refreshTasks(project.slug);
   }, [transport, refreshTasks]);
@@ -449,7 +446,7 @@ export function TaskboardApp(props: { transport: Transport }) {
           const id = selectedIdRef.current;
           if (!id) return;
           void transport.taskUrgent(id, urgent, detailRef.current?.revision).then(async (updated) => {
-            setDetail(updated);
+            applyDetail(updated);
             const project = selectedProjectRef.current;
             if (project) await refreshTasks(project.slug);
           });

--- a/packages/ui/src/boardDrag.test.ts
+++ b/packages/ui/src/boardDrag.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDragEnd } from "./boardDrag";
+
+describe("resolveDragEnd", () => {
+  const tasks = [
+    { displayId: "TASK-1", column: "todo" as const },
+    { displayId: "TASK-2", column: "done" as const },
+    { displayId: "TASK-3", column: "todo" as const },
+  ];
+
+  it("moves when dropping onto a card in another column", () => {
+    expect(resolveDragEnd("TASK-1", "TASK-2", tasks)).toEqual({
+      kind: "move",
+      displayId: "TASK-1",
+      column: "done",
+    });
+  });
+
+  it("reorders when dropping onto a card in the same column", () => {
+    expect(resolveDragEnd("TASK-1", "TASK-3", tasks)).toEqual({
+      kind: "reorder",
+      displayId: "TASK-1",
+      beforeId: "TASK-3",
+    });
+  });
+
+  it("moves when dropping onto a column droppable", () => {
+    expect(resolveDragEnd("TASK-1", "done", tasks)).toEqual({
+      kind: "move",
+      displayId: "TASK-1",
+      column: "done",
+    });
+  });
+});

--- a/packages/ui/src/boardDrag.ts
+++ b/packages/ui/src/boardDrag.ts
@@ -1,0 +1,26 @@
+import type { Column } from "@taskboard/types";
+
+import { COLUMN_IDS } from "./columns";
+
+export type DragEndAction =
+  | { kind: "move"; displayId: string; column: Column }
+  | { kind: "reorder"; displayId: string; beforeId: string }
+  | { kind: "none" };
+
+export function resolveDragEnd(
+  activeId: string,
+  overId: string | null | undefined,
+  tasks: readonly { displayId: string; column: Column }[],
+): DragEndAction {
+  if (!overId || activeId === overId) return { kind: "none" };
+  if ((COLUMN_IDS as readonly string[]).includes(overId)) {
+    return { kind: "move", displayId: activeId, column: overId as Column };
+  }
+  const dragged = tasks.find((t) => t.displayId === activeId);
+  const over = tasks.find((t) => t.displayId === overId);
+  if (!dragged || !over) return { kind: "none" };
+  if (dragged.column !== over.column) {
+    return { kind: "move", displayId: activeId, column: over.column };
+  }
+  return { kind: "reorder", displayId: activeId, beforeId: overId };
+}

--- a/packages/ui/src/columns.ts
+++ b/packages/ui/src/columns.ts
@@ -1,0 +1,25 @@
+import type { Column, DisplayStatus } from "@taskboard/types";
+
+export const COLUMNS: { id: Column; label: string }[] = [
+  { id: "todo", label: "Todo" },
+  { id: "in-progress", label: "In Progress" },
+  { id: "in-review", label: "In Review" },
+  { id: "done", label: "Done" },
+];
+
+export const COLUMN_IDS: Column[] = COLUMNS.map((c) => c.id);
+
+export const BADGE_LABEL: Record<DisplayStatus, string | null> = {
+  idle: null,
+  waiting: "Waiting",
+  running: "Running",
+  failed: "Failed",
+  completed: "Done",
+};
+
+export function neighborColumn(column: Column, dir: -1 | 1): Column | null {
+  const i = COLUMN_IDS.indexOf(column);
+  const next = i + dir;
+  if (next < 0 || next >= COLUMN_IDS.length) return null;
+  return COLUMN_IDS[next] ?? null;
+}

--- a/packages/ui/src/css.d.ts
+++ b/packages/ui/src/css.d.ts
@@ -1,0 +1,6 @@
+declare module "*.module.css" {
+  const classes: Record<string, string>;
+  export default classes;
+}
+
+declare module "*.css";

--- a/packages/ui/src/fakeTransport.ts
+++ b/packages/ui/src/fakeTransport.ts
@@ -1,0 +1,244 @@
+import { vi } from "vitest";
+import type { Transport } from "@taskboard/client";
+import type {
+  Column,
+  Project,
+  TaskDetail,
+  TaskSummary,
+} from "@taskboard/types";
+
+function now(): string {
+  return "2026-09-05T00:00:00Z";
+}
+
+function slugify(name: string, existing: Project[]): string {
+  const base = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "untitled";
+  let slug = base;
+  let n = 2;
+  const used = new Set(existing.map((p) => p.slug));
+  while (used.has(slug)) {
+    slug = `${base}-${n}`;
+    n += 1;
+  }
+  return slug;
+}
+
+function asDetail(task: TaskSummary, extras?: Partial<TaskDetail>): TaskDetail {
+  return {
+    ...task,
+    noteMarkdown: "",
+    links: [],
+    runs: [],
+    recentActivities: [],
+    ...extras,
+  };
+}
+
+export function fakeTransport(): Transport {
+  const projects: Project[] = [];
+  const tasks: TaskSummary[] = [];
+  const details = new Map<string, TaskDetail>();
+  let projectSeq = 0;
+  let taskSeq = 0;
+
+  const impl: Transport = {
+    async projectAdd(input) {
+      projectSeq += 1;
+      const project: Project = {
+        id: `p${projectSeq}`,
+        slug: slugify(input.name, projects),
+        name: input.name,
+        repoPath: input.repoPath ?? null,
+        archived: false,
+        noteMarkdown: "",
+        sortOrder: projects.length,
+        revision: 1,
+        createdAt: now(),
+        updatedAt: now(),
+        deletedAt: null,
+      };
+      projects.push(project);
+      return project;
+    },
+    async projectList(includeArchived) {
+      return projects.filter((p) => includeArchived || !p.archived);
+    },
+    async projectUpdate(slug, patch, revision) {
+      const p = projects.find((x) => x.slug === slug);
+      if (!p) throw new Error("not found");
+      if (patch.name !== undefined) p.name = patch.name;
+      if (patch.repoPath !== undefined) p.repoPath = patch.repoPath;
+      if (patch.slug !== undefined) p.slug = patch.slug;
+      p.revision = (revision ?? p.revision) + 1;
+      p.updatedAt = now();
+      return { ...p };
+    },
+    async projectReorder(slugs) {
+      slugs.forEach((slug, i) => {
+        const p = projects.find((x) => x.slug === slug);
+        if (p) p.sortOrder = i;
+      });
+      projects.sort((a, b) => a.sortOrder - b.sortOrder);
+      return [...projects];
+    },
+    async projectArchive(slug, archived, revision) {
+      const p = projects.find((x) => x.slug === slug);
+      if (!p) throw new Error("not found");
+      p.archived = archived;
+      p.revision = (revision ?? p.revision) + 1;
+      return { ...p };
+    },
+    async projectDelete(slug, revision) {
+      const p = projects.find((x) => x.slug === slug);
+      if (!p) throw new Error("not found");
+      p.deletedAt = now();
+      p.revision = (revision ?? p.revision) + 1;
+      return { ...p };
+    },
+    async projectRestore(slug) {
+      const p = projects.find((x) => x.slug === slug);
+      if (!p) throw new Error("not found");
+      p.deletedAt = null;
+      p.revision += 1;
+      return { ...p };
+    },
+    async projectNoteSet(slug, markdown, revision) {
+      const p = projects.find((x) => x.slug === slug);
+      if (!p) throw new Error("not found");
+      p.noteMarkdown = markdown;
+      p.revision = (revision ?? p.revision) + 1;
+      return { ...p };
+    },
+    async taskCreate(projectSlug, input) {
+      const project = projects.find((x) => x.slug === projectSlug);
+      if (!project) throw new Error("not found");
+      taskSeq += 1;
+      const task: TaskSummary = {
+        id: `t${taskSeq}`,
+        displayId: `TASK-${taskSeq}`,
+        projectId: project.id,
+        title: input.title,
+        column: input.column ?? "todo",
+        urgent: input.urgent ?? false,
+        revision: 1,
+        displayStatus: "idle",
+        runMessage: null,
+      };
+      tasks.push(task);
+      const detail = asDetail(task);
+      details.set(task.displayId, detail);
+      return detail;
+    },
+    async taskList(projectSlug) {
+      const project = projects.find((x) => x.slug === projectSlug);
+      if (!project) return [];
+      return tasks.filter((t) => t.projectId === project.id);
+    },
+    async taskShow(displayId) {
+      const detail = details.get(displayId);
+      if (!detail) throw new Error("not found");
+      return { ...detail, links: [...detail.links], runs: [...detail.runs], recentActivities: [...detail.recentActivities] };
+    },
+    async taskUpdate(displayId, patch, revision) {
+      const task = tasks.find((t) => t.displayId === displayId);
+      const detail = details.get(displayId);
+      if (!task || !detail) throw new Error("not found");
+      if (patch.title !== undefined) task.title = patch.title;
+      if (patch.urgent !== undefined) task.urgent = patch.urgent;
+      if (patch.column !== undefined) task.column = patch.column;
+      if (patch.noteMarkdown !== undefined) detail.noteMarkdown = patch.noteMarkdown;
+      task.revision = (revision ?? task.revision) + 1;
+      Object.assign(detail, task);
+      details.set(displayId, { ...detail });
+      return details.get(displayId)!;
+    },
+    async taskMove(displayId, column: Column, revision) {
+      return impl.taskUpdate(displayId, { column }, revision);
+    },
+    async taskReorder(displayId, beforeDisplayId, revision) {
+      const from = tasks.findIndex((t) => t.displayId === displayId);
+      if (from < 0) throw new Error("not found");
+      const [item] = tasks.splice(from, 1);
+      if (beforeDisplayId) {
+        const to = tasks.findIndex((t) => t.displayId === beforeDisplayId);
+        tasks.splice(to < 0 ? tasks.length : to, 0, item);
+      } else {
+        tasks.push(item);
+      }
+      item.revision = (revision ?? item.revision) + 1;
+      const detail = details.get(displayId);
+      if (detail) {
+        Object.assign(detail, item);
+        details.set(displayId, { ...detail });
+      }
+      return details.get(displayId)!;
+    },
+    async taskUrgent(displayId, urgent, revision) {
+      return impl.taskUpdate(displayId, { urgent }, revision);
+    },
+    async taskDelete(displayId, revision) {
+      const task = tasks.find((t) => t.displayId === displayId);
+      if (!task) throw new Error("not found");
+      task.revision = (revision ?? task.revision) + 1;
+      const idx = tasks.findIndex((t) => t.displayId === displayId);
+      tasks.splice(idx, 1);
+      return details.get(displayId)!;
+    },
+    async taskRestore(displayId) {
+      const detail = details.get(displayId);
+      if (!detail) throw new Error("not found");
+      if (!tasks.some((t) => t.displayId === displayId)) {
+        tasks.push(detail);
+      }
+      return { ...detail };
+    },
+    async taskNoteSet(displayId, markdown, revision) {
+      return impl.taskUpdate(displayId, { noteMarkdown: markdown }, revision);
+    },
+    async linkAdd(displayId, input) {
+      const detail = details.get(displayId);
+      if (!detail) throw new Error("not found");
+      detail.links.push({
+        id: `l${detail.links.length + 1}`,
+        taskId: detail.id,
+        kind: input.kind,
+        value: input.value,
+        sortOrder: detail.links.length,
+      });
+      return { ...detail, links: [...detail.links] };
+    },
+    async linkRemove(linkId) {
+      for (const detail of details.values()) {
+        const i = detail.links.findIndex((l) => l.id === linkId);
+        if (i >= 0) {
+          detail.links.splice(i, 1);
+          return { ...detail, links: [...detail.links] };
+        }
+      }
+      throw new Error("not found");
+    },
+    async runStart() {
+      throw new Error("not implemented");
+    },
+    async runPatch() {
+      throw new Error("not implemented");
+    },
+    async trashList() {
+      return { projects: [], tasks: [] };
+    },
+    async undo() {
+      return {};
+    },
+    async sync() {
+      return { sequence: 0, projects: [], tasks: [], runs: [] };
+    },
+  };
+
+  return Object.fromEntries(
+    (Object.keys(impl) as (keyof Transport)[]).map((key) => [key, vi.fn(impl[key])]),
+  ) as unknown as Transport;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,7 @@
+export { TaskboardApp } from "./TaskboardApp";
+export { Board } from "./Board";
+export { Card } from "./Card";
+export { EmptyState } from "./EmptyState";
+export { Inspector } from "./Inspector";
+export { Search } from "./Search";
+export { Sidebar } from "./Sidebar";

--- a/packages/ui/src/keyboard.test.tsx
+++ b/packages/ui/src/keyboard.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { fakeTransport } from "./fakeTransport";
+import { TaskboardApp } from "./index";
+
+describe("keyboard", () => {
+  it("n creates a task through transport", async () => {
+    const transport = fakeTransport();
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(screen.getByRole("button", { name: "New project" }));
+    // fakeTransport.projectAdd resolves; press n
+    await userEvent.keyboard("n");
+    await waitFor(() => expect(transport.taskCreate).toHaveBeenCalled());
+  });
+
+  it("p creates a project through transport", async () => {
+    const transport = fakeTransport();
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.keyboard("p");
+    expect(transport.projectAdd).toHaveBeenCalledWith({ name: "Untitled" });
+  });
+
+  it("u toggles urgent on the selected card", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Urgent me", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByText("Urgent me"));
+    await userEvent.keyboard("u");
+    await waitFor(() => expect(transport.taskUrgent).toHaveBeenCalled());
+  });
+
+  it("slash focuses search and Escape clears it", async () => {
+    const transport = fakeTransport();
+    await transport.projectAdd({ name: "Untitled" });
+    render(<TaskboardApp transport={transport} />);
+    await screen.findByRole("list", { name: "Todo" });
+    await userEvent.keyboard("/");
+    const search = screen.getByRole("searchbox", { name: "Search" });
+    expect(document.activeElement).toBe(search);
+    await userEvent.keyboard("hello");
+    expect((search as HTMLInputElement).value).toBe("hello");
+    await userEvent.keyboard("{Escape}");
+    expect((search as HTMLInputElement).value).toBe("");
+  });
+
+  it("1-4 jump columns so n creates in the current column", async () => {
+    const transport = fakeTransport();
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(screen.getByRole("button", { name: "New project" }));
+    await waitFor(() => expect(transport.projectAdd).toHaveBeenCalled());
+    await screen.findByRole("list", { name: "Todo" });
+    await userEvent.keyboard("2");
+    await userEvent.keyboard("n");
+    await waitFor(() =>
+      expect(transport.taskCreate).toHaveBeenCalledWith("untitled", {
+        title: "Untitled",
+        column: "in-progress",
+      }),
+    );
+  });
+
+  it("j and k move selection within the current column", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "First", column: "todo" });
+    await transport.taskCreate(project.slug, { title: "Second", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await screen.findByText("First");
+    await userEvent.keyboard("j");
+    expect(screen.getByRole("listitem", { name: /First/ }).getAttribute("aria-selected")).toBe("true");
+    await userEvent.keyboard("j");
+    expect(screen.getByRole("listitem", { name: /Second/ }).getAttribute("aria-selected")).toBe("true");
+    await userEvent.keyboard("k");
+    expect(screen.getByRole("listitem", { name: /First/ }).getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("l moves the selected card to the next column", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Move me", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByText("Move me"));
+    await userEvent.keyboard("l");
+    await waitFor(() => expect(transport.taskMove).toHaveBeenCalled());
+  });
+
+  it("Enter opens the inspector for the selected card", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Inspect me", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await screen.findByText("Inspect me");
+    await userEvent.keyboard("j");
+    await userEvent.keyboard("{Enter}");
+    expect(await screen.findByLabelText("Title")).toBeTruthy();
+    expect(screen.queryByText("Select a card")).toBeNull();
+  });
+});

--- a/packages/ui/src/summary.ts
+++ b/packages/ui/src/summary.ts
@@ -1,0 +1,16 @@
+import type { TaskSummary } from "@taskboard/types";
+
+export function summary(overrides: Partial<TaskSummary> = {}): TaskSummary {
+  return {
+    id: "t1",
+    displayId: "TASK-1",
+    projectId: "p1",
+    title: "Example",
+    column: "todo",
+    urgent: false,
+    revision: 1,
+    displayStatus: "idle",
+    runMessage: null,
+    ...overrides,
+  };
+}

--- a/packages/ui/src/test/setup.ts
+++ b/packages/ui/src/test/setup.ts
@@ -1,0 +1,6 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/ui/src/theme.css
+++ b/packages/ui/src/theme.css
@@ -1,0 +1,27 @@
+:root {
+  --sidebar-bg: #1c1b22;
+  --board-bg: #f4f2f8;
+  --accent: #5b4bdb;
+  --accent-2: #7c6cff;
+  --urgent: #e24a2b;
+  --waiting: #d89a1a;
+  --completed: #2f9e62;
+  --running: #5b4bdb;
+  --sidebar-fg: #f4f2f8;
+  --sidebar-muted: #a9a6b3;
+  --board-fg: #1c1b22;
+  --card-bg: rgba(255, 255, 255, 0.82);
+  --card-border: rgba(28, 27, 34, 0.08);
+  --failed: #c45c4a;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent-2);
+  outline-offset: 2px;
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,11 +22,122 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)
+        version: 3.2.7(@types/node@22.20.1)(jsdom@26.1.0)
 
   packages/types: {}
 
+  packages/ui:
+    dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
+      '@taskboard/client':
+        specifier: workspace:*
+        version: link:../client
+      '@taskboard/types':
+        specifier: workspace:*
+        version: link:../types
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.7(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^18.3.24
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jsdom@26.1.0)
+
 packages:
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
@@ -332,6 +443,34 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.3':
+    resolution: {integrity: sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.7':
+    resolution: {integrity: sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -343,6 +482,17 @@ packages:
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
@@ -373,6 +523,21 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -389,6 +554,17 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -398,9 +574,23 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -431,11 +621,53 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -447,6 +679,12 @@ packages:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nwsapi@2.2.27:
+    resolution: {integrity: sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -466,10 +704,43 @@ packages:
     resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   rollup@4.63.1:
     resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -486,6 +757,9 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -508,6 +782,24 @@ packages:
   tinyspy@4.0.6:
     resolution: {integrity: sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -590,12 +882,115 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
 snapshots:
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
@@ -755,6 +1150,33 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.63.1':
     optional: true
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@testing-library/user-event@14.6.7(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -767,6 +1189,17 @@ snapshots:
   '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@vitest/expect@3.2.7':
     dependencies:
@@ -810,6 +1243,16 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   assertion-error@2.0.1: {}
 
   cac@6.7.14: {}
@@ -824,11 +1267,31 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
+
+  dequal@2.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  entities@6.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -874,9 +1337,70 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
   js-tokens@9.0.1: {}
 
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.27
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -885,6 +1409,12 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.18: {}
+
+  nwsapi@2.2.27: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   pathe@2.0.3: {}
 
@@ -899,6 +1429,26 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-is@17.0.2: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   rollup@4.63.1:
     dependencies:
@@ -932,6 +1482,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.63.1
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -943,6 +1505,8 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
 
@@ -958,6 +1522,22 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.6: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tslib@2.8.1: {}
 
   typescript@5.9.3: {}
 
@@ -996,7 +1576,7 @@ snapshots:
       '@types/node': 22.20.1
       fsevents: 2.3.3
 
-  vitest@3.2.7(@types/node@22.20.1):
+  vitest@3.2.7(@types/node@22.20.1)(jsdom@26.1.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -1023,6 +1603,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -1037,7 +1618,30 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #17

Adds `@taskboard/ui`: Native Glass sidebar/board/inspector, card run badges, keyboard (`j k h l 1 2 3 4 n p u / Escape Enter`), search, 400ms note debounce, and dnd-kit drag (column drop moves; same-column card drop reorders; cross-column card drop moves). `TaskboardApp({ transport })` is the entry.

Inspector mutations keep last-seen revision so notes send a current `If-Match`.

## Verification

- `pnpm --filter @taskboard/ui test` — 22 passed
- `pnpm --filter @taskboard/client test` — 5 passed
- Root `pnpm test` now has both filters.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

