### PR TITLE
feat: add TauriTransport for desktop invoke

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,2 +1,4 @@
 export { HttpTransport } from "./http";
+export { TauriTransport } from "./tauri";
+export type { InvokeFn } from "./tauri";
 export type { Transport } from "./transport";

--- a/packages/client/src/tauri.test.ts
+++ b/packages/client/src/tauri.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import { TauriTransport, type InvokeFn } from "./tauri";
+
+type Call = { cmd: string; args?: Record<string, unknown> };
+
+function recordingInvoke(result: unknown = {}): { calls: Call[]; invoke: InvokeFn } {
+  const calls: Call[] = [];
+  const invoke: InvokeFn = async (cmd, args) => {
+    calls.push({ cmd, args });
+    return result as never;
+  };
+  return { calls, invoke };
+}
+
+describe("TauriTransport", () => {
+  it("invokes project_add with camelCase payload mapped to rust args", async () => {
+    const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
+    const invoke: InvokeFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      return {
+        id: "00000000-0000-7000-0000-000000000001",
+        slug: "renai-sim",
+        name: "Renai Sim",
+        revision: 1,
+      } as never;
+    };
+    const t = new TauriTransport(invoke);
+    const p = await t.projectAdd({ name: "Renai Sim" });
+    assert.equal(calls[0].cmd, "project_add");
+    assert.equal(p.slug, "renai-sim");
+  });
+
+  it("maps camelCase keys to snake_case invoke args and omits undefined", async () => {
+    const { calls, invoke } = recordingInvoke({ slug: "renai-sim" });
+    const t = new TauriTransport(invoke);
+    await t.projectAdd({ name: "Renai Sim", repoPath: "/tmp/renai" });
+    assert.deepEqual(calls[0].args, { name: "Renai Sim", repo_path: "/tmp/renai" });
+    assert.equal("repoPath" in (calls[0].args ?? {}), false);
+  });
+
+  it("includes revision when provided and maps display_id", async () => {
+    const { calls, invoke } = recordingInvoke({ displayId: "TASK-1" });
+    const t = new TauriTransport(invoke);
+    await t.taskMove("TASK-1", "done", 4);
+    assert.equal(calls[0].cmd, "task_move");
+    assert.deepEqual(calls[0].args, { display_id: "TASK-1", column: "done", revision: 4 });
+  });
+
+  it("omits revision when not provided", async () => {
+    const { calls, invoke } = recordingInvoke({ displayId: "TASK-1" });
+    const t = new TauriTransport(invoke);
+    await t.taskDelete("TASK-1");
+    assert.deepEqual(calls[0].args, { display_id: "TASK-1" });
+  });
+
+  it("passes before_display_id null to move to end", async () => {
+    const { calls, invoke } = recordingInvoke({ displayId: "TASK-1" });
+    const t = new TauriTransport(invoke);
+    await t.taskReorder("TASK-1");
+    assert.equal(calls[0].cmd, "task_reorder");
+    assert.equal(calls[0].args?.before_display_id, null);
+    assert.equal("before_display_id" in (calls[0].args ?? {}), true);
+  });
+
+  it("passes before_display_id when placing before another card", async () => {
+    const { calls, invoke } = recordingInvoke({ displayId: "TASK-1" });
+    const t = new TauriTransport(invoke);
+    await t.taskReorder("TASK-1", "TASK-2", 3);
+    assert.deepEqual(calls[0].args, {
+      display_id: "TASK-1",
+      before_display_id: "TASK-2",
+      revision: 3,
+    });
+  });
+
+  it("rethrows AppErrorDto with .code on the Error", async () => {
+    const invoke: InvokeFn = async () => {
+      throw { code: "validation_error", message: "title is required", field: "title", current: null };
+    };
+    const t = new TauriTransport(invoke);
+    await assert.rejects(
+      () => t.projectAdd({ name: "x" }),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, "title is required");
+        assert.equal((err as Error & { code: string }).code, "validation_error");
+        return true;
+      },
+    );
+  });
+
+  it("does not swallow non-dto invoke rejections", async () => {
+    const invoke: InvokeFn = async () => {
+      throw new Error("invoke exploded");
+    };
+    const t = new TauriTransport(invoke);
+    await assert.rejects(() => t.undo(), { message: "invoke exploded" });
+  });
+
+  it("returns invoke results as-is without HTTP envelopes", async () => {
+    const entity = { sequence: 2, projects: [{ slug: "a" }], tasks: [], runs: [] };
+    const { invoke } = recordingInvoke(entity);
+    const t = new TauriTransport(invoke);
+    const delta = await t.sync(1);
+    assert.equal(delta, entity);
+  });
+
+  it("does not call fetch", async () => {
+    const fetches: string[] = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (input) => {
+      fetches.push(String(input));
+      return new Response("{}");
+    }) as typeof fetch;
+    try {
+      const { invoke } = recordingInvoke({ slug: "a" });
+      const t = new TauriTransport(invoke);
+      await t.projectList(false);
+      assert.deepEqual(fetches, []);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("maps every Transport method to the snake_case command", async () => {
+    const { calls, invoke } = recordingInvoke({});
+    const t = new TauriTransport(invoke);
+
+    await t.projectAdd({ name: "A" });
+    await t.projectList(true);
+    await t.projectUpdate("renai-sim", { name: "Renai", repoPath: "/tmp", slug: "renai" }, 2);
+    await t.projectReorder(["a", "b"]);
+    await t.projectArchive("a", true, 1);
+    await t.projectDelete("a", 1);
+    await t.projectRestore("a");
+    await t.projectNoteSet("a", "# n", 1);
+    await t.taskCreate("a", { title: "T", column: "todo", urgent: true });
+    await t.taskList("a");
+    await t.taskShow("TASK-1");
+    await t.taskUpdate("TASK-1", { title: "U", noteMarkdown: "md" }, 1);
+    await t.taskMove("TASK-1", "done");
+    await t.taskReorder("TASK-1", undefined, 1);
+    await t.taskUrgent("TASK-1", false, 1);
+    await t.taskDelete("TASK-1");
+    await t.taskRestore("TASK-1");
+    await t.taskNoteSet("TASK-1", "note", 1);
+    await t.linkAdd("TASK-1", { kind: "url", value: "https://example.com" });
+    await t.linkRemove("link-id", 1);
+    await t.runStart("TASK-1", { agent: "codex", sessionId: "sess" });
+    await t.runPatch("RUN-1", { op: "fail", summary: "boom" }, 1);
+    await t.trashList();
+    await t.undo();
+    await t.sync(0);
+
+    const cmds = calls.map((c) => c.cmd);
+    assert.deepEqual(cmds, [
+      "project_add",
+      "project_list",
+      "project_update",
+      "project_reorder",
+      "project_archive",
+      "project_delete",
+      "project_restore",
+      "project_note_set",
+      "task_create",
+      "task_list",
+      "task_show",
+      "task_update",
+      "task_move",
+      "task_reorder",
+      "task_urgent",
+      "task_delete",
+      "task_restore",
+      "task_note_set",
+      "link_add",
+      "link_remove",
+      "run_start",
+      "run_patch",
+      "trash_list",
+      "undo",
+      "sync",
+    ]);
+
+    assert.deepEqual(calls[1].args, { include_archived: true });
+    assert.deepEqual(calls[2].args, {
+      slug: "renai-sim",
+      name: "Renai",
+      repo_path: "/tmp",
+      new_slug: "renai",
+      revision: 2,
+    });
+    assert.deepEqual(calls[7].args, { slug: "a", markdown: "# n", revision: 1 });
+    assert.deepEqual(calls[8].args, {
+      project_slug: "a",
+      title: "T",
+      column: "todo",
+      urgent: true,
+    });
+    assert.deepEqual(calls[11].args, {
+      display_id: "TASK-1",
+      title: "U",
+      note_markdown: "md",
+      revision: 1,
+    });
+    assert.deepEqual(calls[20].args, {
+      display_id: "TASK-1",
+      agent: "codex",
+      session_id: "sess",
+    });
+    assert.deepEqual(calls[21].args, {
+      run_display_id: "RUN-1",
+      op: "fail",
+      summary: "boom",
+      revision: 1,
+    });
+    assert.equal(calls[22].args, undefined);
+    assert.equal(calls[23].args, undefined);
+    assert.deepEqual(calls[24].args, { after: 0 });
+  });
+});

--- a/packages/client/src/tauri.ts
+++ b/packages/client/src/tauri.ts
@@ -1,0 +1,189 @@
+import type {
+  Column,
+  Project,
+  ProjectPatch,
+  Run,
+  RunOp,
+  SyncDelta,
+  TaskDetail,
+  TaskPatch,
+  TaskSummary,
+  Trash,
+  UndoResult,
+} from "@taskboard/types";
+
+import type { Transport } from "./transport";
+
+export type InvokeFn = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+
+type AppErrorDto = {
+  code: string;
+  message: string;
+  field?: string;
+  current?: unknown;
+};
+
+export class TransportError extends Error {
+  readonly code: string;
+  readonly field?: string;
+  readonly current?: unknown;
+
+  constructor(dto: AppErrorDto) {
+    super(dto.message);
+    this.name = "TransportError";
+    this.code = dto.code;
+    this.field = dto.field;
+    this.current = dto.current;
+  }
+}
+
+function camelToSnake(key: string): string {
+  return key.replace(/[A-Z]/g, (ch) => `_${ch.toLowerCase()}`);
+}
+
+function snakeArgs(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) continue;
+    out[camelToSnake(key)] = value;
+  }
+  return out;
+}
+
+function isAppErrorDto(value: unknown): value is AppErrorDto {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { code?: unknown }).code === "string"
+  );
+}
+
+export class TauriTransport implements Transport {
+  constructor(private readonly invokeFn: InvokeFn) {}
+
+  projectAdd(input: { name: string; repoPath?: string; slug?: string }): Promise<Project> {
+    return this.call("project_add", input);
+  }
+
+  projectList(includeArchived: boolean): Promise<Project[]> {
+    return this.call("project_list", { includeArchived });
+  }
+
+  projectUpdate(slug: string, patch: ProjectPatch, revision?: number): Promise<Project> {
+    const { slug: newSlug, ...rest } = patch;
+    return this.call("project_update", {
+      slug,
+      ...rest,
+      ...(newSlug !== undefined ? { newSlug } : {}),
+      revision,
+    });
+  }
+
+  projectReorder(slugs: string[]): Promise<Project[]> {
+    return this.call("project_reorder", { slugs });
+  }
+
+  projectArchive(slug: string, archived: boolean, revision?: number): Promise<Project> {
+    return this.call("project_archive", { slug, archived, revision });
+  }
+
+  projectDelete(slug: string, revision?: number): Promise<Project> {
+    return this.call("project_delete", { slug, revision });
+  }
+
+  projectRestore(slug: string): Promise<Project> {
+    return this.call("project_restore", { slug });
+  }
+
+  projectNoteSet(slug: string, markdown: string, revision?: number): Promise<Project> {
+    return this.call("project_note_set", { slug, markdown, revision });
+  }
+
+  taskCreate(
+    projectSlug: string,
+    input: { title: string; column?: Column; urgent?: boolean },
+  ): Promise<TaskDetail> {
+    return this.call("task_create", { projectSlug, ...input });
+  }
+
+  taskList(projectSlug: string): Promise<TaskSummary[]> {
+    return this.call("task_list", { projectSlug });
+  }
+
+  taskShow(displayId: string): Promise<TaskDetail> {
+    return this.call("task_show", { displayId });
+  }
+
+  taskUpdate(displayId: string, patch: TaskPatch, revision?: number): Promise<TaskDetail> {
+    return this.call("task_update", { displayId, ...patch, revision });
+  }
+
+  taskMove(displayId: string, column: Column, revision?: number): Promise<TaskDetail> {
+    return this.call("task_move", { displayId, column, revision });
+  }
+
+  taskReorder(displayId: string, beforeDisplayId?: string, revision?: number): Promise<TaskDetail> {
+    return this.call("task_reorder", {
+      displayId,
+      beforeDisplayId: beforeDisplayId ?? null,
+      revision,
+    });
+  }
+
+  taskUrgent(displayId: string, urgent: boolean, revision?: number): Promise<TaskDetail> {
+    return this.call("task_urgent", { displayId, urgent, revision });
+  }
+
+  taskDelete(displayId: string, revision?: number): Promise<TaskDetail> {
+    return this.call("task_delete", { displayId, revision });
+  }
+
+  taskRestore(displayId: string): Promise<TaskDetail> {
+    return this.call("task_restore", { displayId });
+  }
+
+  taskNoteSet(displayId: string, markdown: string, revision?: number): Promise<TaskDetail> {
+    return this.call("task_note_set", { displayId, markdown, revision });
+  }
+
+  linkAdd(displayId: string, input: { kind: "url" | "path"; value: string }): Promise<TaskDetail> {
+    return this.call("link_add", { displayId, ...input });
+  }
+
+  linkRemove(linkId: string, revision?: number): Promise<TaskDetail> {
+    return this.call("link_remove", { linkId, revision });
+  }
+
+  runStart(displayId: string, input: { agent: string; sessionId?: string }): Promise<Run> {
+    return this.call("run_start", { displayId, ...input });
+  }
+
+  runPatch(runDisplayId: string, op: RunOp, revision?: number): Promise<Run> {
+    return this.call("run_patch", { runDisplayId, ...op, revision });
+  }
+
+  trashList(): Promise<Trash> {
+    return this.call("trash_list");
+  }
+
+  undo(): Promise<UndoResult> {
+    return this.call("undo");
+  }
+
+  sync(after: number): Promise<SyncDelta> {
+    return this.call("sync", { after });
+  }
+
+  private async call<T>(cmd: string, raw?: Record<string, unknown>): Promise<T> {
+    const args = raw === undefined ? undefined : snakeArgs(raw);
+    const invokeArgs = args && Object.keys(args).length > 0 ? args : undefined;
+    try {
+      return await this.invokeFn<T>(cmd, invokeArgs);
+    } catch (err) {
+      if (isAppErrorDto(err)) {
+        throw new TransportError(err);
+      }
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #19

Adds `TauriTransport` that implements the same `Transport` as `HttpTransport`, using injected `invoke` with snake_case command names and camelCase→snake_case args. No `fetch`. Invoke errors expose AppError `code`.

## Verification

- `pnpm --filter @taskboard/client test` — 16 passed (11 Tauri + 5 Http)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

