### PR TITLE
feat: add Tauri command wrappers around App

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,6 +2114,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "taskboard-desktop-commands"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "taskboard-application",
+ "taskboard-core",
+ "taskboard-store-sqlite",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "taskboard-store-sqlite"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,11 @@ members = [
     "crates/store-sqlite",
     "crates/cli",
     "crates/api",
+    "crates/desktop-commands",
 ]
+# apps/desktop/src-tauri (taskboard-desktop) is excluded: this Linux
+# environment has no webkit2gtk-4.1, and root `cargo test` must stay green.
+exclude = ["apps/desktop/src-tauri"]
 
 [workspace.package]
 edition = "2021"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "taskboard-desktop"
+version = "0.1.0"
+description = "Taskboard desktop shell"
+edition = "2021"
+license = "MIT"
+rust-version = "1.83"
+
+# Excluded from the workspace: Linux CI has no webkit2gtk-4.1, and Tauri 2.6's
+# crate graph currently pulls edition2024 packages that need rustc > 1.83.
+# Wrappers live here; command logic is tested via taskboard-desktop-commands.
+
+[lib]
+name = "taskboard_desktop_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[build-dependencies]
+tauri-build = { version = "=2.6.2", features = [] }
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tauri = { version = "=2.6.2", features = [] }
+taskboard-application = { path = "../../../crates/application" }
+taskboard-core = { path = "../../../crates/core" }
+taskboard-desktop-commands = { path = "../../../crates/desktop-commands" }
+taskboard-store-sqlite = { path = "../../../crates/store-sqlite" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,6 @@
+{
+  "identifier": "default",
+  "description": "Default permissions for the Taskboard window",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,0 +1,330 @@
+use taskboard_core::{Column, LinkKind};
+use taskboard_desktop_commands::{
+    deserialize_present_option, link_add_inner, link_remove_inner, project_add_inner,
+    project_archive_inner, project_delete_inner, project_list_inner, project_note_set_inner,
+    project_reorder_inner, project_restore_inner, project_update_inner, run_patch_inner,
+    run_start_inner, sync_inner, task_create_inner, task_delete_inner, task_list_inner,
+    task_move_inner, task_note_set_inner, task_reorder_inner, task_restore_inner, task_show_inner,
+    task_update_inner, task_urgent_inner, trash_list_inner, undo_inner, AppErrorDto, ProjectDto,
+    RunDto, RunOp, SyncDeltaDto, TaskDetailDto, TaskPatchArgs, TaskSummaryDto, TrashDto,
+    UndoResultDto,
+};
+
+use crate::state::DesktopState;
+
+#[tauri::command]
+pub async fn project_add(
+    state: tauri::State<'_, DesktopState>,
+    name: String,
+    repo_path: Option<String>,
+    slug: Option<String>,
+) -> Result<ProjectDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_add_inner(&app, name, repo_path, slug)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn project_list(
+    state: tauri::State<'_, DesktopState>,
+    include_archived: bool,
+) -> Result<Vec<ProjectDto>, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_list_inner(&app, include_archived)
+        .await
+        .map(|items| items.into_iter().map(Into::into).collect())
+}
+
+#[tauri::command]
+pub async fn project_update(
+    state: tauri::State<'_, DesktopState>,
+    slug: String,
+    name: Option<String>,
+    repo_path: Option<String>,
+    new_slug: Option<String>,
+    revision: Option<i64>,
+) -> Result<ProjectDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_update_inner(&app, slug, name, repo_path, new_slug, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn project_reorder(
+    state: tauri::State<'_, DesktopState>,
+    slugs: Vec<String>,
+) -> Result<Vec<ProjectDto>, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_reorder_inner(&app, slugs)
+        .await
+        .map(|items| items.into_iter().map(Into::into).collect())
+}
+
+#[tauri::command]
+pub async fn project_archive(
+    state: tauri::State<'_, DesktopState>,
+    slug: String,
+    archived: bool,
+    revision: Option<i64>,
+) -> Result<ProjectDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_archive_inner(&app, slug, archived, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn project_delete(
+    state: tauri::State<'_, DesktopState>,
+    slug: String,
+    revision: Option<i64>,
+) -> Result<ProjectDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_delete_inner(&app, slug, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn project_restore(
+    state: tauri::State<'_, DesktopState>,
+    slug: String,
+) -> Result<ProjectDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_restore_inner(&app, slug).await.map(Into::into)
+}
+
+#[tauri::command]
+pub async fn project_note_set(
+    state: tauri::State<'_, DesktopState>,
+    slug: String,
+    markdown: String,
+    revision: Option<i64>,
+) -> Result<ProjectDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    project_note_set_inner(&app, slug, markdown, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_create(
+    state: tauri::State<'_, DesktopState>,
+    project_slug: String,
+    title: String,
+    column: Option<Column>,
+    urgent: Option<bool>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_create_inner(&app, project_slug, title, column, urgent)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_list(
+    state: tauri::State<'_, DesktopState>,
+    project_slug: String,
+) -> Result<Vec<TaskSummaryDto>, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_list_inner(&app, project_slug)
+        .await
+        .map(|items| items.into_iter().map(Into::into).collect())
+}
+
+#[tauri::command]
+pub async fn task_show(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_show_inner(&app, display_id).await.map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_update(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    title: Option<String>,
+    note_markdown: Option<String>,
+    urgent: Option<bool>,
+    column: Option<Column>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    before_display_id: Option<Option<String>>,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_update_inner(
+        &app,
+        TaskPatchArgs {
+            display_id,
+            title,
+            note_markdown,
+            urgent,
+            column,
+            before_display_id,
+            revision,
+        },
+    )
+    .await
+    .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_move(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    column: Column,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_move_inner(&app, display_id, column, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_reorder(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    before_display_id: Option<String>,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_reorder_inner(&app, display_id, before_display_id, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_urgent(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    urgent: bool,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_urgent_inner(&app, display_id, urgent, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_delete(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_delete_inner(&app, display_id, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_restore(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_restore_inner(&app, display_id).await.map(Into::into)
+}
+
+#[tauri::command]
+pub async fn task_note_set(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    markdown: String,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    task_note_set_inner(&app, display_id, markdown, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn link_add(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    kind: LinkKind,
+    value: String,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    link_add_inner(&app, display_id, kind, value, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn link_remove(
+    state: tauri::State<'_, DesktopState>,
+    link_id: String,
+    revision: Option<i64>,
+) -> Result<TaskDetailDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    link_remove_inner(&app, link_id, revision)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn run_start(
+    state: tauri::State<'_, DesktopState>,
+    display_id: String,
+    agent: String,
+    session_id: Option<String>,
+) -> Result<RunDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    run_start_inner(&app, display_id, agent, session_id)
+        .await
+        .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn run_patch(
+    state: tauri::State<'_, DesktopState>,
+    run_display_id: String,
+    op: RunOp,
+    message: Option<String>,
+    reason: Option<String>,
+    summary: Option<String>,
+    revision: Option<i64>,
+) -> Result<RunDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    run_patch_inner(
+        &app,
+        run_display_id,
+        op,
+        message,
+        reason,
+        summary,
+        revision,
+    )
+    .await
+    .map(Into::into)
+}
+
+#[tauri::command]
+pub async fn trash_list(state: tauri::State<'_, DesktopState>) -> Result<TrashDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    trash_list_inner(&app).await.map(Into::into)
+}
+
+#[tauri::command]
+pub async fn undo(state: tauri::State<'_, DesktopState>) -> Result<UndoResultDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    undo_inner(&app).await.map(Into::into)
+}
+
+#[tauri::command]
+pub async fn sync(
+    state: tauri::State<'_, DesktopState>,
+    after: i64,
+) -> Result<SyncDeltaDto, AppErrorDto> {
+    let app = state.app.lock().await;
+    sync_inner(&app, after).await.map(Into::into)
+}

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -12,7 +12,8 @@ use taskboard_desktop_commands::{
 
 use crate::state::DesktopState;
 
-#[tauri::command]
+// IPC keys match TauriTransport snake_case.
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_add(
     state: tauri::State<'_, DesktopState>,
     name: String,
@@ -25,7 +26,7 @@ pub async fn project_add(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_list(
     state: tauri::State<'_, DesktopState>,
     include_archived: bool,
@@ -36,7 +37,7 @@ pub async fn project_list(
         .map(|items| items.into_iter().map(Into::into).collect())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_update(
     state: tauri::State<'_, DesktopState>,
     slug: String,
@@ -51,7 +52,7 @@ pub async fn project_update(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_reorder(
     state: tauri::State<'_, DesktopState>,
     slugs: Vec<String>,
@@ -62,7 +63,7 @@ pub async fn project_reorder(
         .map(|items| items.into_iter().map(Into::into).collect())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_archive(
     state: tauri::State<'_, DesktopState>,
     slug: String,
@@ -75,7 +76,7 @@ pub async fn project_archive(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_delete(
     state: tauri::State<'_, DesktopState>,
     slug: String,
@@ -87,7 +88,7 @@ pub async fn project_delete(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_restore(
     state: tauri::State<'_, DesktopState>,
     slug: String,
@@ -96,7 +97,7 @@ pub async fn project_restore(
     project_restore_inner(&app, slug).await.map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn project_note_set(
     state: tauri::State<'_, DesktopState>,
     slug: String,
@@ -109,7 +110,7 @@ pub async fn project_note_set(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_create(
     state: tauri::State<'_, DesktopState>,
     project_slug: String,
@@ -123,7 +124,7 @@ pub async fn task_create(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_list(
     state: tauri::State<'_, DesktopState>,
     project_slug: String,
@@ -134,7 +135,7 @@ pub async fn task_list(
         .map(|items| items.into_iter().map(Into::into).collect())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_show(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -143,7 +144,7 @@ pub async fn task_show(
     task_show_inner(&app, display_id).await.map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_update(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -172,7 +173,7 @@ pub async fn task_update(
     .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_move(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -185,7 +186,7 @@ pub async fn task_move(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_reorder(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -198,7 +199,7 @@ pub async fn task_reorder(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_urgent(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -211,7 +212,7 @@ pub async fn task_urgent(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_delete(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -223,7 +224,7 @@ pub async fn task_delete(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_restore(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -232,7 +233,7 @@ pub async fn task_restore(
     task_restore_inner(&app, display_id).await.map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn task_note_set(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -245,7 +246,7 @@ pub async fn task_note_set(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn link_add(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -259,7 +260,7 @@ pub async fn link_add(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn link_remove(
     state: tauri::State<'_, DesktopState>,
     link_id: String,
@@ -271,7 +272,7 @@ pub async fn link_remove(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn run_start(
     state: tauri::State<'_, DesktopState>,
     display_id: String,
@@ -284,7 +285,7 @@ pub async fn run_start(
         .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn run_patch(
     state: tauri::State<'_, DesktopState>,
     run_display_id: String,
@@ -308,19 +309,19 @@ pub async fn run_patch(
     .map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn trash_list(state: tauri::State<'_, DesktopState>) -> Result<TrashDto, AppErrorDto> {
     let app = state.app.lock().await;
     trash_list_inner(&app).await.map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn undo(state: tauri::State<'_, DesktopState>) -> Result<UndoResultDto, AppErrorDto> {
     let app = state.app.lock().await;
     undo_inner(&app).await.map(Into::into)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn sync(
     state: tauri::State<'_, DesktopState>,
     after: i64,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,0 +1,60 @@
+mod commands;
+mod state;
+
+use chrono::Utc;
+use taskboard_application::{App, SystemClock};
+use taskboard_store_sqlite::{open_db, resolve_data_dir, SqliteStore};
+
+use state::DesktopState;
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .setup(|app| {
+            let data_dir = resolve_data_dir(None, std::env::var_os("TASKBOARD_DATA_DIR").as_deref());
+            let handle = app.handle().clone();
+            tauri::async_runtime::block_on(async move {
+                let pool = open_db(&data_dir).await.map_err(|err| err.to_string())?;
+                let store = SqliteStore::new(pool, &data_dir);
+                let board = App::new(store, SystemClock);
+                board
+                    .purge_expired_trash(Utc::now())
+                    .await
+                    .map_err(|err| err.to_string())?;
+                handle.manage(DesktopState {
+                    app: tokio::sync::Mutex::new(board),
+                });
+                Ok::<(), String>(())
+            })?;
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            commands::project_add,
+            commands::project_list,
+            commands::project_update,
+            commands::project_reorder,
+            commands::project_archive,
+            commands::project_delete,
+            commands::project_restore,
+            commands::project_note_set,
+            commands::task_create,
+            commands::task_list,
+            commands::task_show,
+            commands::task_update,
+            commands::task_move,
+            commands::task_reorder,
+            commands::task_urgent,
+            commands::task_delete,
+            commands::task_restore,
+            commands::task_note_set,
+            commands::link_add,
+            commands::link_remove,
+            commands::run_start,
+            commands::run_patch,
+            commands::trash_list,
+            commands::undo,
+            commands::sync,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running Taskboard");
+}

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,0 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    taskboard_desktop_lib::run();
+}

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -1,0 +1,5 @@
+use taskboard_application::App;
+
+pub struct DesktopState {
+    pub app: tokio::sync::Mutex<App>,
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Taskboard",
+  "version": "0.1.0",
+  "identifier": "com.taskboard.app",
+  "build": {
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "withGlobalTauri": false,
+    "windows": [
+      {
+        "label": "main",
+        "title": "Taskboard",
+        "width": 960,
+        "height": 640,
+        "minWidth": 960,
+        "minHeight": 640
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ipc: http://ipc.localhost"
+    }
+  },
+  "bundle": {
+    "active": false
+  }
+}

--- a/crates/desktop-commands/Cargo.toml
+++ b/crates/desktop-commands/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "taskboard-desktop-commands"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+taskboard-application = { path = "../application" }
+taskboard-core = { path = "../core" }
+uuid.workspace = true
+
+[dev-dependencies]
+tempfile = "=3.19.1"
+taskboard-store-sqlite = { path = "../store-sqlite" }
+tokio.workspace = true

--- a/crates/desktop-commands/src/commands.rs
+++ b/crates/desktop-commands/src/commands.rs
@@ -1,0 +1,415 @@
+use taskboard_application::{
+    Actor, App, AppError, LinkAdd, ProjectAdd, ProjectUpdate, RunFail, RunFinish, RunStart,
+    RunUpdate, RunWait, SyncDelta, TaskCreate, TaskUpdate, Trash, UndoResult,
+};
+use taskboard_core::{ActorKind, Column, LinkKind, Project, Run, TaskDetail, TaskSummary};
+use uuid::Uuid;
+
+use crate::dto::RunOp;
+use crate::error::AppErrorDto;
+
+pub fn desktop_actor() -> Actor {
+    Actor {
+        kind: ActorKind::Desktop,
+        label: "local-ui".into(),
+    }
+}
+
+fn actor() -> Actor {
+    desktop_actor()
+}
+
+fn missing(field: &str) -> AppErrorDto {
+    AppError::Validation {
+        field: field.into(),
+        message: format!("{field} is required"),
+    }
+    .into()
+}
+
+pub async fn project_add_inner(
+    app: &App,
+    name: String,
+    repo_path: Option<String>,
+    slug: Option<String>,
+) -> Result<Project, AppErrorDto> {
+    app.project_add(
+        &actor(),
+        ProjectAdd {
+            name,
+            repo_path,
+            slug,
+        },
+    )
+    .await
+    .map_err(Into::into)
+}
+
+pub async fn project_list_inner(
+    app: &App,
+    include_archived: bool,
+) -> Result<Vec<Project>, AppErrorDto> {
+    app.project_list(include_archived).await.map_err(Into::into)
+}
+
+pub async fn project_update_inner(
+    app: &App,
+    slug: String,
+    name: Option<String>,
+    repo_path: Option<String>,
+    new_slug: Option<String>,
+    revision: Option<i64>,
+) -> Result<Project, AppErrorDto> {
+    app.project_update(
+        &actor(),
+        ProjectUpdate {
+            slug,
+            name,
+            repo_path,
+            new_slug,
+            revision,
+        },
+    )
+    .await
+    .map_err(Into::into)
+}
+
+pub async fn project_reorder_inner(
+    app: &App,
+    slugs: Vec<String>,
+) -> Result<Vec<Project>, AppErrorDto> {
+    app.project_reorder(&actor(), &slugs)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn project_archive_inner(
+    app: &App,
+    slug: String,
+    archived: bool,
+    revision: Option<i64>,
+) -> Result<Project, AppErrorDto> {
+    app.project_archive(&actor(), &slug, archived, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn project_delete_inner(
+    app: &App,
+    slug: String,
+    revision: Option<i64>,
+) -> Result<Project, AppErrorDto> {
+    app.project_delete(&actor(), &slug, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn project_restore_inner(app: &App, slug: String) -> Result<Project, AppErrorDto> {
+    app.project_restore(&actor(), &slug)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn project_note_set_inner(
+    app: &App,
+    slug: String,
+    markdown: String,
+    revision: Option<i64>,
+) -> Result<Project, AppErrorDto> {
+    app.project_note_set(&actor(), &slug, markdown, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn task_create_inner(
+    app: &App,
+    project_slug: String,
+    title: String,
+    column: Option<Column>,
+    urgent: Option<bool>,
+) -> Result<TaskDetail, AppErrorDto> {
+    app.task_create(
+        &actor(),
+        TaskCreate {
+            project_slug,
+            title,
+            column,
+            urgent: urgent.unwrap_or(false),
+        },
+    )
+    .await
+    .map_err(Into::into)
+}
+
+pub async fn task_list_inner(
+    app: &App,
+    project_slug: String,
+) -> Result<Vec<TaskSummary>, AppErrorDto> {
+    app.task_list(&project_slug).await.map_err(Into::into)
+}
+
+pub async fn task_show_inner(app: &App, display_id: String) -> Result<TaskDetail, AppErrorDto> {
+    app.task_show(&display_id).await.map_err(Into::into)
+}
+
+pub struct TaskPatchArgs {
+    pub display_id: String,
+    pub title: Option<String>,
+    pub note_markdown: Option<String>,
+    pub urgent: Option<bool>,
+    pub column: Option<Column>,
+    pub before_display_id: Option<Option<String>>,
+    pub revision: Option<i64>,
+}
+
+pub async fn task_update_inner(app: &App, patch: TaskPatchArgs) -> Result<TaskDetail, AppErrorDto> {
+    let actor = actor();
+    let TaskPatchArgs {
+        display_id,
+        title,
+        note_markdown,
+        urgent,
+        column,
+        before_display_id,
+        mut revision,
+    } = patch;
+    let mut task = None;
+    if title.is_some() {
+        let updated = app
+            .task_update(
+                &actor,
+                TaskUpdate {
+                    display_id: display_id.clone(),
+                    title,
+                    revision,
+                },
+            )
+            .await?;
+        revision = Some(updated.revision);
+        task = Some(updated);
+    }
+    if let Some(markdown) = note_markdown {
+        let updated = app
+            .task_note_set(&actor, &display_id, markdown, revision)
+            .await?;
+        revision = Some(updated.revision);
+        task = Some(updated);
+    }
+    if let Some(urgent) = urgent {
+        let updated = app
+            .task_urgent(&actor, &display_id, urgent, revision)
+            .await?;
+        revision = Some(updated.revision);
+        task = Some(updated);
+    }
+    if let Some(column) = column {
+        let updated = app.task_move(&actor, &display_id, column, revision).await?;
+        revision = Some(updated.revision);
+        task = Some(updated);
+    }
+    if let Some(before) = before_display_id {
+        let updated = app
+            .task_reorder(&actor, &display_id, before.as_deref(), revision)
+            .await?;
+        task = Some(updated);
+    }
+    match task {
+        Some(task) => Ok(task),
+        None => app.task_show(&display_id).await.map_err(Into::into),
+    }
+}
+
+pub async fn task_move_inner(
+    app: &App,
+    display_id: String,
+    column: Column,
+    revision: Option<i64>,
+) -> Result<TaskDetail, AppErrorDto> {
+    app.task_move(&actor(), &display_id, column, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn task_reorder_inner(
+    app: &App,
+    display_id: String,
+    before_display_id: Option<String>,
+    revision: Option<i64>,
+) -> Result<TaskDetail, AppErrorDto> {
+    app.task_reorder(
+        &actor(),
+        &display_id,
+        before_display_id.as_deref(),
+        revision,
+    )
+    .await
+    .map_err(Into::into)
+}
+
+pub async fn task_urgent_inner(
+    app: &App,
+    display_id: String,
+    urgent: bool,
+    revision: Option<i64>,
+) -> Result<TaskDetail, AppErrorDto> {
+    app.task_urgent(&actor(), &display_id, urgent, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn task_delete_inner(
+    app: &App,
+    display_id: String,
+    revision: Option<i64>,
+) -> Result<TaskDetail, AppErrorDto> {
+    app.task_delete(&actor(), &display_id, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn task_restore_inner(app: &App, display_id: String) -> Result<TaskDetail, AppErrorDto> {
+    app.task_restore(&actor(), &display_id)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn task_note_set_inner(
+    app: &App,
+    display_id: String,
+    markdown: String,
+    revision: Option<i64>,
+) -> Result<TaskDetail, AppErrorDto> {
+    app.task_note_set(&actor(), &display_id, markdown, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn link_add_inner(
+    app: &App,
+    display_id: String,
+    kind: LinkKind,
+    value: String,
+    revision: Option<i64>,
+) -> Result<TaskDetail, AppErrorDto> {
+    app.link_add(
+        &actor(),
+        LinkAdd {
+            task_display_id: display_id,
+            kind,
+            value,
+            revision,
+        },
+    )
+    .await
+    .map_err(Into::into)
+}
+
+pub async fn link_remove_inner(
+    app: &App,
+    link_id: String,
+    revision: Option<i64>,
+) -> Result<TaskDetail, AppErrorDto> {
+    let id = Uuid::parse_str(&link_id).map_err(|_| {
+        AppErrorDto::from(AppError::Validation {
+            field: "link_id".into(),
+            message: "invalid uuid".into(),
+        })
+    })?;
+    app.link_remove(&actor(), id, revision)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn run_start_inner(
+    app: &App,
+    display_id: String,
+    agent: String,
+    session_id: Option<String>,
+) -> Result<Run, AppErrorDto> {
+    app.run_start(
+        &actor(),
+        RunStart {
+            task_display_id: display_id,
+            agent,
+            session_id,
+        },
+    )
+    .await
+    .map_err(Into::into)
+}
+
+pub async fn run_patch_inner(
+    app: &App,
+    run_display_id: String,
+    op: RunOp,
+    message: Option<String>,
+    reason: Option<String>,
+    summary: Option<String>,
+    revision: Option<i64>,
+) -> Result<Run, AppErrorDto> {
+    let actor = actor();
+    match op {
+        RunOp::Update => app
+            .run_update(
+                &actor,
+                RunUpdate {
+                    run_display_id,
+                    message,
+                    revision,
+                },
+            )
+            .await
+            .map_err(Into::into),
+        RunOp::Wait => {
+            let reason = reason.ok_or_else(|| missing("reason"))?;
+            app.run_wait(
+                &actor,
+                RunWait {
+                    run_display_id,
+                    reason,
+                    revision,
+                },
+            )
+            .await
+            .map_err(Into::into)
+        }
+        RunOp::Fail => {
+            let summary = summary.ok_or_else(|| missing("summary"))?;
+            app.run_fail(
+                &actor,
+                RunFail {
+                    run_display_id,
+                    summary,
+                    revision,
+                },
+            )
+            .await
+            .map_err(Into::into)
+        }
+        RunOp::Finish => {
+            let summary = summary.ok_or_else(|| missing("summary"))?;
+            app.run_finish(
+                &actor,
+                RunFinish {
+                    run_display_id,
+                    summary,
+                    revision,
+                },
+            )
+            .await
+            .map_err(Into::into)
+        }
+    }
+}
+
+pub async fn trash_list_inner(app: &App) -> Result<Trash, AppErrorDto> {
+    app.trash_list().await.map_err(Into::into)
+}
+
+pub async fn undo_inner(app: &App) -> Result<UndoResult, AppErrorDto> {
+    app.undo(&actor()).await.map_err(Into::into)
+}
+
+pub async fn sync_inner(app: &App, after: i64) -> Result<SyncDelta, AppErrorDto> {
+    app.sync(after).await.map_err(Into::into)
+}

--- a/crates/desktop-commands/src/dto.rs
+++ b/crates/desktop-commands/src/dto.rs
@@ -1,0 +1,339 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use taskboard_application::{SyncDelta, Trash, UndoResult};
+use taskboard_core::{
+    Activity, ActorKind, CardDisplayStatus, Column, EntityType, Link, LinkKind, Project, Run,
+    RunStatus, TaskDetail, TaskSummary,
+};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectDto {
+    pub id: Uuid,
+    pub slug: String,
+    pub name: String,
+    pub repo_path: Option<String>,
+    pub archived: bool,
+    pub note_markdown: String,
+    pub sort_order: i64,
+    pub revision: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl From<Project> for ProjectDto {
+    fn from(project: Project) -> Self {
+        Self {
+            id: project.id,
+            slug: project.slug,
+            name: project.name,
+            repo_path: project.repo_path,
+            archived: project.archived,
+            note_markdown: project.note_markdown,
+            sort_order: project.sort_order,
+            revision: project.revision,
+            created_at: project.created_at,
+            updated_at: project.updated_at,
+            deleted_at: project.deleted_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskSummaryDto {
+    pub id: Uuid,
+    pub display_id: String,
+    pub project_id: Uuid,
+    pub title: String,
+    pub column: Column,
+    pub urgent: bool,
+    pub revision: i64,
+    pub display_status: CardDisplayStatus,
+    pub run_message: Option<String>,
+}
+
+impl From<TaskSummary> for TaskSummaryDto {
+    fn from(task: TaskSummary) -> Self {
+        Self {
+            id: task.id,
+            display_id: task.display_id,
+            project_id: task.project_id,
+            title: task.title,
+            column: task.column,
+            urgent: task.urgent,
+            revision: task.revision,
+            display_status: task.display_status,
+            run_message: task.run_message,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkDto {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub kind: LinkKind,
+    pub value: String,
+    pub sort_order: i64,
+}
+
+impl From<Link> for LinkDto {
+    fn from(link: Link) -> Self {
+        Self {
+            id: link.id,
+            task_id: link.task_id,
+            kind: link.kind,
+            value: link.value,
+            sort_order: link.sort_order,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunDto {
+    pub id: Uuid,
+    pub display_id: String,
+    pub task_id: Uuid,
+    pub agent: String,
+    pub session_id: Option<String>,
+    pub status: RunStatus,
+    pub message: Option<String>,
+    pub waiting_reason: Option<String>,
+    pub summary: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    pub revision: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<Run> for RunDto {
+    fn from(run: Run) -> Self {
+        Self {
+            id: run.id,
+            display_id: run.display_id,
+            task_id: run.task_id,
+            agent: run.agent,
+            session_id: run.session_id,
+            status: run.status,
+            message: run.message,
+            waiting_reason: run.waiting_reason,
+            summary: run.summary,
+            started_at: run.started_at,
+            ended_at: run.ended_at,
+            revision: run.revision,
+            created_at: run.created_at,
+            updated_at: run.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityDto {
+    pub id: Uuid,
+    pub sequence: i64,
+    pub actor_kind: ActorKind,
+    pub actor_label: String,
+    pub operation: String,
+    pub entity_type: EntityType,
+    pub entity_id: Uuid,
+    pub previous_revision: Option<i64>,
+    pub before_json: Option<Value>,
+    pub after_json: Option<Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<Activity> for ActivityDto {
+    fn from(activity: Activity) -> Self {
+        Self {
+            id: activity.id,
+            sequence: activity.sequence,
+            actor_kind: activity.actor_kind,
+            actor_label: activity.actor_label,
+            operation: activity.operation,
+            entity_type: activity.entity_type,
+            entity_id: activity.entity_id,
+            previous_revision: activity.previous_revision,
+            before_json: activity.before_json,
+            after_json: activity.after_json,
+            created_at: activity.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskDetailDto {
+    pub id: Uuid,
+    pub display_id: String,
+    pub project_id: Uuid,
+    pub title: String,
+    pub column: Column,
+    pub urgent: bool,
+    pub revision: i64,
+    pub display_status: CardDisplayStatus,
+    pub run_message: Option<String>,
+    pub note_markdown: String,
+    pub links: Vec<LinkDto>,
+    pub runs: Vec<RunDto>,
+    pub recent_activities: Vec<ActivityDto>,
+}
+
+impl From<TaskDetail> for TaskDetailDto {
+    fn from(task: TaskDetail) -> Self {
+        Self {
+            id: task.id,
+            display_id: task.display_id,
+            project_id: task.project_id,
+            title: task.title,
+            column: task.column,
+            urgent: task.urgent,
+            revision: task.revision,
+            display_status: task.display_status,
+            run_message: task.run_message,
+            note_markdown: task.note_markdown,
+            links: task.links.into_iter().map(LinkDto::from).collect(),
+            runs: task.runs.into_iter().map(RunDto::from).collect(),
+            recent_activities: task
+                .recent_activities
+                .into_iter()
+                .map(ActivityDto::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncDeltaDto {
+    pub sequence: i64,
+    pub projects: Vec<ProjectDto>,
+    pub tasks: Vec<TaskDetailDto>,
+    pub runs: Vec<RunDto>,
+}
+
+impl From<SyncDelta> for SyncDeltaDto {
+    fn from(delta: SyncDelta) -> Self {
+        Self {
+            sequence: delta.sequence,
+            projects: delta.projects.into_iter().map(ProjectDto::from).collect(),
+            tasks: delta.tasks.into_iter().map(TaskDetailDto::from).collect(),
+            runs: delta.runs.into_iter().map(RunDto::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrashDto {
+    pub projects: Vec<ProjectDto>,
+    pub tasks: Vec<TaskSummaryDto>,
+}
+
+impl From<Trash> for TrashDto {
+    fn from(trash: Trash) -> Self {
+        Self {
+            projects: trash.projects.into_iter().map(ProjectDto::from).collect(),
+            tasks: trash.tasks.into_iter().map(TaskSummaryDto::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UndoResultDto {
+    pub entity_type: EntityType,
+    pub entity: Value,
+}
+
+impl From<UndoResult> for UndoResultDto {
+    fn from(result: UndoResult) -> Self {
+        Self {
+            entity_type: result.entity_type,
+            entity: json_keys_to_camel(result.entity),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RunOp {
+    Update,
+    Wait,
+    Fail,
+    Finish,
+}
+
+/// Distinguishes JSON field absent (`None`) from explicit `null` (`Some(None)`).
+pub fn deserialize_present_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
+}
+
+pub fn json_keys_to_camel(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, nested)| (snake_to_camel(&key), json_keys_to_camel(nested)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(json_keys_to_camel).collect()),
+        other => other,
+    }
+}
+
+fn snake_to_camel(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut upper = false;
+    for ch in raw.chars() {
+        if ch == '_' {
+            upper = true;
+        } else if upper {
+            out.extend(ch.to_uppercase());
+            upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProjectDto;
+    use chrono::{TimeZone, Utc};
+    use taskboard_core::Project;
+    use uuid::Uuid;
+
+    #[test]
+    fn project_dto_serializes_camel_case_keys() {
+        let dto = ProjectDto::from(Project {
+            id: Uuid::nil(),
+            slug: "renai-sim".into(),
+            name: "Renai Sim".into(),
+            repo_path: None,
+            archived: false,
+            note_markdown: String::new(),
+            sort_order: 0,
+            revision: 1,
+            created_at: Utc.timestamp_opt(0, 0).unwrap(),
+            updated_at: Utc.timestamp_opt(0, 0).unwrap(),
+            deleted_at: None,
+        });
+        let value = serde_json::to_value(&dto).unwrap();
+        assert!(value.get("noteMarkdown").is_some());
+        assert!(value.get("note_markdown").is_none());
+        assert!(value.get("repoPath").is_some());
+        assert_eq!(value["slug"], "renai-sim");
+    }
+}

--- a/crates/desktop-commands/src/error.rs
+++ b/crates/desktop-commands/src/error.rs
@@ -1,0 +1,61 @@
+use serde::Serialize;
+use serde_json::Value;
+use taskboard_application::AppError;
+
+use crate::dto::json_keys_to_camel;
+
+/// Invoke error payload. Keys match `{ "code", "message", "field", "current" }`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AppErrorDto {
+    pub code: String,
+    pub message: String,
+    pub field: Option<String>,
+    pub current: Option<Value>,
+}
+
+impl std::fmt::Display for AppErrorDto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for AppErrorDto {}
+
+impl From<AppError> for AppErrorDto {
+    fn from(err: AppError) -> Self {
+        let code = err.code().to_string();
+        let message = err.to_string();
+        let (field, current) = match err {
+            AppError::Validation { field, .. } => (Some(field), None),
+            AppError::RevisionConflict { current } | AppError::UndoConflict { current } => {
+                (None, Some(json_keys_to_camel(current)))
+            }
+            _ => (None, None),
+        };
+        Self {
+            code,
+            message,
+            field,
+            current,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppErrorDto;
+    use taskboard_application::AppError;
+
+    #[test]
+    fn app_error_dto_serializes_brief_shape() {
+        let err = AppErrorDto::from(AppError::Validation {
+            field: "title".into(),
+            message: "must not be empty".into(),
+        });
+        let value = serde_json::to_value(&err).unwrap();
+        assert_eq!(value["code"], "validation_error");
+        assert_eq!(value["message"], "must not be empty");
+        assert_eq!(value["field"], "title");
+        assert_eq!(value["current"], serde_json::Value::Null);
+    }
+}

--- a/crates/desktop-commands/src/lib.rs
+++ b/crates/desktop-commands/src/lib.rs
@@ -1,0 +1,7 @@
+mod commands;
+mod dto;
+mod error;
+
+pub use commands::*;
+pub use dto::*;
+pub use error::AppErrorDto;

--- a/crates/desktop-commands/tests/commands.rs
+++ b/crates/desktop-commands/tests/commands.rs
@@ -1,0 +1,61 @@
+use std::ops::Deref;
+
+use taskboard_application::{App, AppError, SystemClock};
+use taskboard_desktop_commands::{project_add_inner, sync_inner, AppErrorDto};
+use taskboard_store_sqlite::{open_db, SqliteStore};
+
+#[test]
+fn app_error_dto_serializes_code_message_field_current() {
+    let err = AppErrorDto::from(AppError::Validation {
+        field: "title".into(),
+        message: "must not be empty".into(),
+    });
+    let value = serde_json::to_value(&err).unwrap();
+    assert_eq!(value["code"], "validation_error");
+    assert_eq!(value["message"], "must not be empty");
+    assert_eq!(value["field"], "title");
+    assert_eq!(value["current"], serde_json::Value::Null);
+}
+
+struct TestApp {
+    app: App,
+    _tmp: tempfile::TempDir,
+}
+
+impl Deref for TestApp {
+    type Target = App;
+
+    fn deref(&self) -> &Self::Target {
+        &self.app
+    }
+}
+
+async fn test_app() -> TestApp {
+    let tmp = tempfile::tempdir().unwrap();
+    let pool = open_db(tmp.path()).await.unwrap();
+    let store = SqliteStore::new(pool, tmp.path());
+    TestApp {
+        app: App::new(store, SystemClock),
+        _tmp: tmp,
+    }
+}
+
+#[tokio::test]
+async fn project_add_command_creates_slug() {
+    let app = test_app().await;
+    let p = project_add_inner(&app, "Renai Sim".into(), None, None)
+        .await
+        .unwrap();
+    assert_eq!(p.slug, "renai-sim");
+}
+
+#[tokio::test]
+async fn sync_sees_cli_equivalent_write_on_same_app() {
+    let app = test_app().await;
+    project_add_inner(&app, "A".into(), None, None)
+        .await
+        .unwrap();
+    let delta = sync_inner(&app, 0).await.unwrap();
+    assert!(delta.sequence >= 1);
+    assert_eq!(delta.projects[0].slug, "a");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #20

Adds `taskboard-desktop-commands` wrapping `App` for every desktop invoke listed in Task 1. Linux CI can test these without webkit. `apps/desktop/src-tauri` has Tauri 2 wrappers, `DesktopState`, and `tauri.conf.json` (`com.taskboard.app`) but is not a workspace member because this image lacks `webkit2gtk-4.1` and current Tauri exceeds rustc 1.83.

Commands use `rename_all = "snake_case"` so they match `TauriTransport`. Success DTOs are camelCase. Actor is `desktop` / `local-ui`. No HTTP/TCP.

## Verification

- `cargo test -p taskboard-desktop-commands -- --test-threads=1` — 5 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

