### PR TITLE
feat: load shared board UI in the Tauri window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 **/*.sqlite3-*
 .DS_Store
 apps/web/dist
+apps/desktop/dist

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Taskboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@taskboard/desktop",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.66.0",
+    "@tauri-apps/api": "2.6.0",
+    "@taskboard/client": "workspace:*",
+    "@taskboard/ui": "workspace:*",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^18.3.24",
+    "@types/react-dom": "^18.3.7",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^26.1.0",
+    "typescript": "^5.9.2",
+    "vite": "^5.4.14",
+    "vitest": "^3.2.4"
+  }
+}

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import type { InvokeFn } from "@taskboard/client";
+import { describe, expect, it } from "vitest";
+
+import { AppWithInvoke } from "./App";
+
+describe("desktop App", () => {
+  it("does not call fetch on first render", async () => {
+    const invoke: InvokeFn = async (cmd) => {
+      if (cmd === "project_list") return [] as never;
+      if (cmd === "sync") {
+        return { sequence: 0, projects: [], tasks: [], runs: [] } as never;
+      }
+      return { projects: [], sequence: 0 } as never;
+    };
+    const fetchCalls: string[] = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      fetchCalls.push(String(input));
+      return original(input, init);
+    };
+    try {
+      render(<AppWithInvoke invoke={invoke} />);
+      expect(fetchCalls).toEqual([]);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { TauriTransport, type InvokeFn } from "@taskboard/client";
+import { TaskboardApp } from "@taskboard/ui";
+
+// Never import HttpTransport under apps/desktop. Desktop uses TauriTransport + invoke only.
+
+function refetchInterval(visibility: DocumentVisibilityState): number | false {
+  return visibility === "visible" ? 1000 : false;
+}
+
+function BoardShell({ invoke: invokeFn }: { invoke: InvokeFn }) {
+  const transport = useMemo(() => new TauriTransport(invokeFn), [invokeFn]);
+  const lastSeq = useRef(0);
+  const [boardSeq, setBoardSeq] = useState(0);
+  const [visible, setVisible] = useState(
+    () => typeof document === "undefined" || document.visibilityState === "visible",
+  );
+
+  useEffect(() => {
+    const onChange = () => setVisible(document.visibilityState === "visible");
+    document.addEventListener("visibilitychange", onChange);
+    return () => document.removeEventListener("visibilitychange", onChange);
+  }, []);
+
+  useQuery({
+    queryKey: ["sync"],
+    queryFn: async () => {
+      const delta = await transport.sync(lastSeq.current);
+      if (delta.sequence !== lastSeq.current) {
+        lastSeq.current = delta.sequence;
+        setBoardSeq(delta.sequence);
+      }
+      return delta;
+    },
+    refetchInterval: refetchInterval(visible ? "visible" : "hidden"),
+  });
+
+  return <TaskboardApp transport={transport} sequence={boardSeq} />;
+}
+
+export function AppWithInvoke({ invoke }: { invoke: InvokeFn }) {
+  const [queryClient] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BoardShell invoke={invoke} />
+    </QueryClientProvider>
+  );
+}
+
+export function App() {
+  return <AppWithInvoke invoke={invoke} />;
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,0 +1,9 @@
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("missing #root");
+}
+createRoot(root).render(<App />);

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -1,0 +1,6 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,0 +1,17 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
+  optimizeDeps: {
+    exclude: ["@taskboard/ui", "@taskboard/client", "@taskboard/types"],
+  },
+  server: {
+    fs: {
+      allow: ["../.."],
+    },
+  },
+});

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "packageManager": "pnpm@10.33.3",
   "scripts": {
-    "test": "pnpm --filter @taskboard/client test && pnpm --filter @taskboard/ui test && pnpm --filter web test"
+    "test": "pnpm --filter @taskboard/client test && pnpm --filter @taskboard/ui test && pnpm --filter web test && pnpm --filter @taskboard/desktop test"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,52 @@ importers:
 
   .: {}
 
+  apps/desktop:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.66.0
+        version: 5.102.8(react@18.3.1)
+      '@taskboard/client':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@taskboard/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tauri-apps/api':
+        specifier: 2.6.0
+        version: 2.6.0
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.3.24
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@5.4.21(@types/node@22.20.1))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.14
+        version: 5.4.21(@types/node@22.20.1)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jsdom@26.1.0)
+
   apps/web:
     dependencies:
       '@tanstack/react-query':
@@ -563,6 +609,9 @@ packages:
     resolution: {integrity: sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tauri-apps/api@2.6.0':
+    resolution: {integrity: sha512-hRNcdercfgpzgFrMXWwNDBN0B7vNzOzRepy6ZAmhxi5mDLVPNrTpo9MGg2tN/F7JRugj4d2aF7E1rtPXAHaetg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1461,6 +1510,8 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.102.8
       react: 18.3.1
+
+  '@tauri-apps/api@2.6.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #21

Desktop Vite app `@taskboard/desktop` loads the shared `TaskboardApp` with `TauriTransport` (no HTTP). Tests inject `AppWithInvoke` and assert first render does not call `fetch`. Visible poll uses `transport.sync` every 1000ms.

## Verification

- `pnpm --filter @taskboard/desktop test` — 1 passed
- `pnpm --filter @taskboard/ui test` — 24 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

