### PR TITLE
feat: undo shortcut and CLI-visible desktop sync

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -23,6 +23,7 @@
     }
   },
   "bundle": {
+    // .dmg and app icons are produced on a macOS builder, not in this environment.
     "active": false
   }
 }

--- a/crates/application/tests/concurrency.rs
+++ b/crates/application/tests/concurrency.rs
@@ -436,3 +436,38 @@ async fn two_pools_second_writer_sees_busy_or_success() {
 
     holder.rollback().await.unwrap();
 }
+
+async fn open_app(dir: &std::path::Path) -> App {
+    let pool = open_db(dir).await.unwrap();
+    App::new(SqliteStore::new(pool, dir), SystemClock)
+}
+
+#[tokio::test]
+async fn second_connection_sees_commit_within_two_seconds() {
+    let dir = tempfile::tempdir().unwrap();
+    let app_a = open_app(dir.path()).await;
+    let app_b = open_app(dir.path()).await;
+    app_a
+        .project_add(
+            &cli_actor(),
+            ProjectAdd {
+                name: "A".into(),
+                repo_path: None,
+                slug: None,
+            },
+        )
+        .await
+        .unwrap();
+    let start = std::time::Instant::now();
+    let mut seq = 0;
+    loop {
+        let delta = app_b.sync(seq).await.unwrap();
+        if delta.projects.iter().any(|p| p.slug == "a") {
+            assert!(start.elapsed() <= std::time::Duration::from_secs(2));
+            break;
+        }
+        seq = delta.sequence;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(start.elapsed() < std::time::Duration::from_secs(2));
+    }
+}

--- a/packages/ui/src/TaskboardApp.tsx
+++ b/packages/ui/src/TaskboardApp.tsx
@@ -284,6 +284,12 @@ export function TaskboardApp(props: { transport: Transport; sequence?: number })
         return;
       }
 
+      if ((e.metaKey || e.ctrlKey) && (e.key === "z" || e.key === "Z")) {
+        e.preventDefault();
+        void transport.undo().then(() => reloadBoard());
+        return;
+      }
+
       if (e.key === "/") {
         e.preventDefault();
         searchRef.current?.focus();
@@ -369,7 +375,18 @@ export function TaskboardApp(props: { transport: Transport; sequence?: number })
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [addProject, createTask, jumpColumn, moveSelected, selectCard, selectInColumn, switchProject, toggleUrgent]);
+  }, [
+    addProject,
+    createTask,
+    jumpColumn,
+    moveSelected,
+    reloadBoard,
+    selectCard,
+    selectInColumn,
+    switchProject,
+    toggleUrgent,
+    transport,
+  ]);
 
   const onMove = useCallback(
     async (displayId: string, column: Column) => {

--- a/packages/ui/src/keyboard.test.tsx
+++ b/packages/ui/src/keyboard.test.tsx
@@ -87,6 +87,13 @@ describe("keyboard", () => {
     await waitFor(() => expect(transport.taskMove).toHaveBeenCalled());
   });
 
+  it("meta+z calls undo", async () => {
+    const transport = fakeTransport();
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.keyboard("{Meta>}z{/Meta}");
+    expect(transport.undo).toHaveBeenCalled();
+  });
+
   it("Enter opens the inspector for the selected card", async () => {
     const transport = fakeTransport();
     const project = await transport.projectAdd({ name: "Untitled" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #22

Binds Meta+Z / Control+Z in the shared `TaskboardApp` to `transport.undo()` and reloads the board. Adds a two-connection SQLite test that a second `App` sees a commit via `sync` within two seconds (WAL). `.dmg` / icons stay macOS-builder only.

## Verification

- `cargo test -p taskboard-application --test concurrency -- --exact second_connection_sees_commit_within_two_seconds` — pass
- `pnpm --filter @taskboard/ui test` — 25 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

