### PR TITLE
ci: add GitHub Actions rust and pnpm test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  HTTP_PROXY: ""
+  HTTPS_PROXY: ""
+  http_proxy: ""
+  https_proxy: ""
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.83.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Test
+        run: cargo test -- --test-threads=1
+
+  js:
+    if: hashFiles('pnpm-lock.yaml') != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,41 +2,52 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
-  HTTP_PROXY: ""
-  HTTPS_PROXY: ""
-  http_proxy: ""
-  https_proxy: ""
 
 jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.83.0
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.83.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.83.0
+      - uses: actions/cache@v4
         with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
       - name: Test
-        run: cargo test -- --test-threads=1
+        run: |
+          unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+          cargo test -- --test-threads=1
 
   js:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Skip when lockfile is absent
+      - name: Detect pnpm lockfile
         id: lockfile
         run: |
           if [ -f pnpm-lock.yaml ]; then
@@ -44,16 +55,20 @@ jobs:
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: pnpm/action-setup@v4
-        if: steps.lockfile.outputs.present == 'true'
       - uses: actions/setup-node@v4
         if: steps.lockfile.outputs.present == 'true'
         with:
           node-version: "22"
-          cache: pnpm
+      - name: Enable pnpm
+        if: steps.lockfile.outputs.present == 'true'
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.3 --activate
       - name: Install
         if: steps.lockfile.outputs.present == 'true'
         run: pnpm install --frozen-lockfile
       - name: Test
         if: steps.lockfile.outputs.present == 'true'
-        run: pnpm test
+        run: |
+          unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+          pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,27 @@ jobs:
         run: cargo test -- --test-threads=1
 
   js:
-    if: hashFiles('pnpm-lock.yaml') != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Skip when lockfile is absent
+        id: lockfile
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: pnpm/action-setup@v4
+        if: steps.lockfile.outputs.present == 'true'
       - uses: actions/setup-node@v4
+        if: steps.lockfile.outputs.present == 'true'
         with:
           node-version: "22"
           cache: pnpm
       - name: Install
+        if: steps.lockfile.outputs.present == 'true'
         run: pnpm install --frozen-lockfile
       - name: Test
+        if: steps.lockfile.outputs.present == 'true'
         run: pnpm test

--- a/crates/core/src/display_status.rs
+++ b/crates/core/src/display_status.rs
@@ -31,9 +31,7 @@ pub fn card_display_status(runs: &[RunStatusView]) -> CardDisplayStatus {
 
     let best = runs
         .iter()
-        .filter(|r| {
-            !has_active || matches!(r.status, RunStatus::Running | RunStatus::Waiting)
-        })
+        .filter(|r| !has_active || matches!(r.status, RunStatus::Running | RunStatus::Waiting))
         .max_by(|a, b| {
             a.started_at
                 .cmp(&b.started_at)

--- a/crates/core/src/ids.rs
+++ b/crates/core/src/ids.rs
@@ -47,9 +47,6 @@ mod tests {
     #[test]
     fn display_ids_round_trip() {
         assert_eq!(display_id(DisplayKind::Task, 142), "TASK-142");
-        assert_eq!(
-            parse_display_id("RUN-37").unwrap(),
-            (DisplayKind::Run, 37)
-        );
+        assert_eq!(parse_display_id("RUN-37").unwrap(), (DisplayKind::Run, 37));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,17 +13,15 @@ mod slug;
 mod validation;
 
 pub use column::{Column, ParseColumnError};
-pub use display_status::{CardDisplayStatus, RunStatusView, card_display_status};
+pub use display_status::{card_display_status, CardDisplayStatus, RunStatusView};
 pub use error::{FieldError, ValidationError};
-pub use ids::{DisplayKind, ParseDisplayIdError, display_id, parse_display_id};
+pub use ids::{display_id, parse_display_id, DisplayKind, ParseDisplayIdError};
 pub use models::{
     Activity, ActorKind, EntityType, Link, LinkKind, Project, Run, Task, TaskDetail, TaskSummary,
 };
-pub use order::{
-    OrderError, OrderKey, place_before, place_urgent, rewrite_positions, sort_column,
-};
+pub use order::{place_before, place_urgent, rewrite_positions, sort_column, OrderError, OrderKey};
 pub use run_status::{ParseRunStatusError, RunStatus};
-pub use slug::{SlugError, next_unique_slug, slugify};
+pub use slug::{next_unique_slug, slugify, SlugError};
 pub use validation::{parse_agent, parse_path_link, parse_url, trim_project_name, trim_title};
 
 #[cfg(test)]

--- a/crates/core/src/order.rs
+++ b/crates/core/src/order.rs
@@ -38,7 +38,10 @@ pub fn place_urgent(keys: &mut Vec<OrderKey>, display_id: &str, urgent: bool) {
     let key = keys.remove(index);
 
     let insert_at = if urgent {
-        keys.iter().rposition(|k| k.urgent).map(|i| i + 1).unwrap_or(0)
+        keys.iter()
+            .rposition(|k| k.urgent)
+            .map(|i| i + 1)
+            .unwrap_or(0)
     } else {
         keys.iter().position(|k| !k.urgent).unwrap_or(keys.len())
     };
@@ -74,7 +77,11 @@ pub fn place_before(
     };
 
     let key = keys.remove(index);
-    let insert_at = if index < insert_at { insert_at - 1 } else { insert_at };
+    let insert_at = if index < insert_at {
+        insert_at - 1
+    } else {
+        insert_at
+    };
     keys.insert(insert_at, key);
     rewrite_positions(keys);
     Ok(())
@@ -330,9 +337,7 @@ mod tests {
 
     #[test]
     fn sort_and_rewrite_positions_property_on_permutations() {
-        let base = make_eight_keys([
-            true, false, true, false, true, false, false, true,
-        ]);
+        let base = make_eight_keys([true, false, true, false, true, false, false, true]);
 
         let permutations: Vec<Vec<usize>> = vec![
             vec![0, 1, 2, 3, 4, 5, 6, 7],

--- a/crates/core/src/validation.rs
+++ b/crates/core/src/validation.rs
@@ -41,7 +41,9 @@ pub fn parse_agent(raw: &str) -> Result<String, ValidationError> {
     if raw.is_empty() || raw.len() > 64 {
         return Err(ValidationError::new(
             AGENT_FIELD,
-            FieldError::Invalid { allowed: AGENT_ALLOWED },
+            FieldError::Invalid {
+                allowed: AGENT_ALLOWED,
+            },
         ));
     }
 
@@ -50,20 +52,19 @@ pub fn parse_agent(raw: &str) -> Result<String, ValidationError> {
     if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
         return Err(ValidationError::new(
             AGENT_FIELD,
-            FieldError::Invalid { allowed: AGENT_ALLOWED },
+            FieldError::Invalid {
+                allowed: AGENT_ALLOWED,
+            },
         ));
     }
 
     for ch in chars {
-        if !ch.is_ascii_lowercase()
-            && !ch.is_ascii_digit()
-            && ch != '.'
-            && ch != '_'
-            && ch != '-'
-        {
+        if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '.' && ch != '_' && ch != '-' {
             return Err(ValidationError::new(
                 AGENT_FIELD,
-                FieldError::Invalid { allowed: AGENT_ALLOWED },
+                FieldError::Invalid {
+                    allowed: AGENT_ALLOWED,
+                },
             ));
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #23

## Summary
GitHub Actions CI on `push`/`pull_request` to `main`:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `pnpm test` when `pnpm-lock.yaml` is present

Proxy env vars are unset around tests so the suite does not depend on outbound HTTP. Apple silicon `.dmg` is not part of this gate.

`rust-toolchain.toml` pins 1.83.0 with rustfmt and clippy.

## Test plan
- [x] Local `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings`
- [ ] GitHub Actions `rust` and `js` jobs green on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

