### PR TITLE
feat: Homebrew tap AI1411/taskboard with tb alias skip

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,32 @@
+name: Packaging
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Formula/**
+      - packaging/homebrew/**
+      - .github/workflows/packaging.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Formula/**
+      - packaging/homebrew/**
+      - .github/workflows/packaging.yml
+
+concurrency:
+  group: packaging-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  homebrew-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tarball layout and alias_skipped
+        run: sh packaging/homebrew/tests/run.sh

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,44 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-cli-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  macos-arm64:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.83.0 --profile minimal
+          rustup default 1.83.0
+      - name: Build CLI
+        run: cargo build --release -p taskboard-cli
+      - name: Pack tarball
+        run: |
+          bash packaging/homebrew/package_cli_tarball.sh \
+            target/release/taskboard \
+            taskboard-aarch64-apple-darwin.tar.gz
+          shasum -a 256 taskboard-aarch64-apple-darwin.tar.gz | tee tarball.sha256
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes="Apple silicon CLI. Archive contains taskboard and a tb symlink. Homebrew postinstall skips a foreign tb and prints alias_skipped."
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" taskboard-aarch64-apple-darwin.tar.gz --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              taskboard-aarch64-apple-darwin.tar.gz \
+              --title "${GITHUB_REF_NAME}" \
+              --notes "${notes}"
+          fi

--- a/Formula/taskboard.rb
+++ b/Formula/taskboard.rb
@@ -1,0 +1,58 @@
+class Taskboard < Formula
+  desc "Local Kanban CLI (taskboard / tb) for Apple silicon"
+  homepage "https://github.com/AI1411/taskboard"
+  license "MIT"
+  version "0.1.0"
+
+  # Binary install (GitHub Release asset produced by .github/workflows/release-cli.yml).
+  url "https://github.com/AI1411/taskboard/releases/download/v#{version}/taskboard-aarch64-apple-darwin.tar.gz"
+  # Updated after the first v0.1.0 CLI tarball is published.
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  head "https://github.com/AI1411/taskboard.git", branch: "main"
+
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+  depends_on "rust" => :build if build.head?
+
+  def install
+    if build.head?
+      system "cargo", "install", "--locked", "--root", prefix, "--path", "crates/cli"
+    else
+      # Tarball also contains a `tb` symlink for non-brew installs; Homebrew
+      # must not link that name from the Cellar so a foreign `tb` can be skipped.
+      bin.install "taskboard"
+    end
+  end
+
+  def post_install
+    taskboard = HOMEBREW_PREFIX/"bin/taskboard"
+    tb = HOMEBREW_PREFIX/"bin/tb"
+    skip = false
+    if tb.exist? || tb.symlink?
+      begin
+        skip = tb.realpath != taskboard.realpath
+      rescue
+        skip = true
+      end
+    end
+    if skip
+      ohai "alias_skipped"
+      puts "alias_skipped"
+    elsif !tb.exist? && !tb.symlink?
+      tb.make_symlink(taskboard)
+    end
+  end
+
+  def caveats
+    <<~EOS
+      Apple silicon (arm64) on macOS 14+ is the supported release target.
+      `taskboard` is always linked. `tb` is created in postinstall unless a
+      foreign `tb` already exists; then postinstall prints alias_skipped.
+    EOS
+  end
+
+  test do
+    assert_match "taskboard", shell_output("#{bin}/taskboard --help")
+  end
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,48 @@
+# Homebrew tap `AI1411/taskboard`
+
+Formula name: `taskboard`. Supported release target: Apple silicon, macOS 14+.
+
+## Install
+
+Preferred (tap repo `https://github.com/AI1411/homebrew-taskboard`):
+
+```bash
+brew tap AI1411/taskboard
+brew install taskboard
+```
+
+If that GitHub repo is not available yet, tap this repository by URL (it contains `Formula/taskboard.rb`):
+
+```bash
+brew tap AI1411/taskboard https://github.com/AI1411/taskboard
+brew install taskboard
+```
+
+Until GitHub Release `v0.1.0` publishes `taskboard-aarch64-apple-darwin.tar.gz`, install from git:
+
+```bash
+brew install --HEAD AI1411/taskboard/taskboard
+```
+
+## Tarball
+
+`packaging/homebrew/package_cli_tarball.sh` packs a `taskboard` binary plus a `tb` symlink. The tag workflow `.github/workflows/release-cli.yml` runs that script on `macos-14` and uploads the asset.
+
+After the first release, replace the placeholder `sha256` in `Formula/taskboard.rb` with:
+
+```bash
+shasum -a 256 taskboard-aarch64-apple-darwin.tar.gz
+```
+
+## `tb` alias
+
+`taskboard` always installs. `tb` is created only when that name is absent or already points at `taskboard`. A foreign `tb` is left in place and the installer prints `alias_skipped`.
+
+- Homebrew: `Formula/taskboard.rb` `post_install`
+- Tarball / prefix installs: `packaging/homebrew/install_tb_alias.sh BINDIR`
+
+## Tests
+
+```bash
+sh packaging/homebrew/tests/run.sh
+```

--- a/packaging/homebrew/install_tb_alias.sh
+++ b/packaging/homebrew/install_tb_alias.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Create bindir/tb -> taskboard unless a foreign `tb` is already present.
+# Prints `alias_skipped` when the alias is left untouched. Always exits 0
+# when bindir/taskboard exists so installers can keep going (issue #24).
+# Usage: install_tb_alias.sh BINDIR
+set -eu
+
+bin_dir=${1:?usage: install_tb_alias.sh BINDIR}
+taskboard="$bin_dir/taskboard"
+tb="$bin_dir/tb"
+
+if [ ! -e "$taskboard" ]; then
+  printf 'install_tb_alias: taskboard not found in %s\n' "$bin_dir" >&2
+  exit 1
+fi
+
+points_at_taskboard() {
+  tb_real=$(realpath "$tb" 2>/dev/null) || return 1
+  taskboard_real=$(realpath "$taskboard") || return 1
+  [ "$tb_real" = "$taskboard_real" ]
+}
+
+if [ -L "$tb" ] || [ -e "$tb" ]; then
+  if points_at_taskboard; then
+    exit 0
+  fi
+  printf '%s\n' 'alias_skipped'
+  exit 0
+fi
+
+ln -s taskboard "$tb"

--- a/packaging/homebrew/package_cli_tarball.sh
+++ b/packaging/homebrew/package_cli_tarball.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Build the CLI release tarball: top-level `taskboard` plus `tb` -> taskboard.
+# Usage: package_cli_tarball.sh /path/to/taskboard OUT.tar.gz
+set -eu
+
+binary=${1:?usage: package_cli_tarball.sh BINARY OUT.tar.gz}
+out=${2:?usage: package_cli_tarball.sh BINARY OUT.tar.gz}
+
+if [ ! -f "$binary" ]; then
+  printf 'package_cli_tarball: not a file: %s\n' "$binary" >&2
+  exit 1
+fi
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+
+cp "$binary" "$stage/taskboard"
+chmod 755 "$stage/taskboard"
+ln -s taskboard "$stage/tb"
+
+tar -C "$stage" -czf "$out" taskboard tb

--- a/packaging/homebrew/tests/run.sh
+++ b/packaging/homebrew/tests/run.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Tests for the CLI tarball layout and tb alias skip rules (issue #24).
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+root=$(CDPATH= cd -- "$here/.." && pwd)
+repo=$(CDPATH= cd -- "$root/../.." && pwd)
+formula="$repo/Formula/taskboard.rb"
+fail=0
+
+assert() {
+  msg=$1
+  shift
+  if "$@"; then
+    printf 'ok  %s\n' "$msg"
+  else
+    printf 'not ok  %s\n' "$msg"
+    fail=1
+  fi
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+printf '#!/bin/sh\necho fake-taskboard\n' >"$tmp/taskboard.bin"
+chmod +x "$tmp/taskboard.bin"
+
+"$root/package_cli_tarball.sh" "$tmp/taskboard.bin" "$tmp/taskboard-aarch64-apple-darwin.tar.gz"
+list=$(tar -tzf "$tmp/taskboard-aarch64-apple-darwin.tar.gz" | LC_ALL=C sort | tr '\n' ' ')
+assert "tarball contains taskboard and tb only" test "$list" = "taskboard tb "
+
+mkdir "$tmp/extract"
+tar -C "$tmp/extract" -xzf "$tmp/taskboard-aarch64-apple-darwin.tar.gz"
+assert "taskboard is an executable file" test -f "$tmp/extract/taskboard" -a -x "$tmp/extract/taskboard"
+assert "tb is a symlink" test -L "$tmp/extract/tb"
+assert "tb points at taskboard" test "$(readlink "$tmp/extract/tb")" = "taskboard"
+
+mkdir "$tmp/bin-empty"
+cp "$tmp/taskboard.bin" "$tmp/bin-empty/taskboard"
+chmod +x "$tmp/bin-empty/taskboard"
+out=$("$root/install_tb_alias.sh" "$tmp/bin-empty")
+assert "fresh install prints nothing" test -z "$out"
+assert "fresh install creates tb symlink" test -L "$tmp/bin-empty/tb"
+assert "fresh tb points at taskboard" test "$(readlink "$tmp/bin-empty/tb")" = "taskboard"
+
+out=$("$root/install_tb_alias.sh" "$tmp/bin-empty")
+assert "idempotent reinstall prints nothing" test -z "$out"
+assert "idempotent reinstall keeps our tb" test -L "$tmp/bin-empty/tb"
+
+mkdir "$tmp/bin-foreign"
+cp "$tmp/taskboard.bin" "$tmp/bin-foreign/taskboard"
+printf 'other-tb\n' >"$tmp/bin-foreign/tb"
+out=$("$root/install_tb_alias.sh" "$tmp/bin-foreign")
+assert "foreign tb prints alias_skipped" test "$out" = "alias_skipped"
+assert "foreign tb contents unchanged" test "$(cat "$tmp/bin-foreign/tb")" = "other-tb"
+assert "taskboard still installed beside foreign tb" test -f "$tmp/bin-foreign/taskboard"
+
+mkdir "$tmp/bin-other-link"
+cp "$tmp/taskboard.bin" "$tmp/bin-other-link/taskboard"
+printf '#!/bin/sh\necho other\n' >"$tmp/bin-other-link/other"
+chmod +x "$tmp/bin-other-link/other"
+ln -s other "$tmp/bin-other-link/tb"
+out=$("$root/install_tb_alias.sh" "$tmp/bin-other-link")
+assert "foreign symlink prints alias_skipped" test "$out" = "alias_skipped"
+assert "foreign symlink still points at other" test "$(readlink "$tmp/bin-other-link/tb")" = "other"
+
+assert "formula exists" test -f "$formula"
+assert "formula class is Taskboard" grep -q '^class Taskboard < Formula$' "$formula"
+assert "formula is Apple silicon only" grep -q 'arch: :arm64' "$formula"
+assert "formula requires macOS 14+" grep -q 'macos: :sonoma' "$formula"
+assert "formula installs from aarch64-apple-darwin tarball" grep -q 'taskboard-aarch64-apple-darwin.tar.gz' "$formula"
+assert "formula postinstall mentions alias_skipped" grep -q 'alias_skipped' "$formula"
+assert "formula does not bin.install tb" awk '/def install/,/^  end$/{if ($0 ~ /bin.install .*tb/) exit 1}' "$formula"
+
+if [ "$fail" -ne 0 ]; then
+  printf '\npackaging/homebrew tests failed\n' >&2
+  exit 1
+fi
+
+printf '\nall packaging/homebrew tests passed\n'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #24

## Summary

Homebrew tap `AI1411/taskboard`, formula name `taskboard`, Apple silicon / macOS 14+.

- `Formula/taskboard.rb` is tap-able from this repo (`brew tap AI1411/taskboard https://github.com/AI1411/taskboard`) and is mirrored to `AI1411/homebrew-taskboard` so `brew tap AI1411/taskboard` works.
- Release tarball layout: `taskboard` binary plus `tb` symlink (`packaging/homebrew/package_cli_tarball.sh`). Tag workflow `.github/workflows/release-cli.yml` builds that archive on `macos-14`.
- Foreign `tb` is skipped; installer prints `alias_skipped`; `taskboard` still installs (`post_install` and `packaging/homebrew/install_tb_alias.sh`).
- Stable URL points at GitHub Release `v0.1.0` (`sha256` placeholder until the first tarball is published). Use `brew install --HEAD AI1411/taskboard/taskboard` until then.

## Test plan

- [x] `sh packaging/homebrew/tests/run.sh` (tarball layout, alias skip, formula constraints)
- [ ] Packaging workflow on this PR
- [ ] Real `brew install AI1411/taskboard/taskboard` on a Mac after the first arm64 tarball exists
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d8e579-3aa6-4c79-977c-8be4f34dfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

