### PR TITLE
style: Linear-dark Kanban restyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 apps/web/dist
 apps/desktop/dist
 .idea
+.superpowers/

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;650&display=swap"
+      rel="stylesheet"
+    />
     <title>Taskboard</title>
   </head>
   <body>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;650&display=swap"
+      rel="stylesheet"
+    />
     <title>Taskboard</title>
   </head>
   <body>

--- a/docs/superpowers/plans/2026-09-06-linear-dark-kanban.md
+++ b/docs/superpowers/plans/2026-09-06-linear-dark-kanban.md
@@ -1,0 +1,602 @@
+# Linear-dark Kanban Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle the local Taskboard web/desktop UI to Linear-dark Kanban: near-black surfaces, Inter, indigo only on primary actions and selection, overlay inspector on a full-width board.
+
+**Architecture:** Keep `packages/ui` components and keyboard/DnD behavior. Replace Native Glass tokens in `theme.css`, flatten CSS modules, and change the shell from a 3-column grid to sidebar + board with a positioned inspector overlay. Empty “Select a card” stays in the DOM (hidden) so existing tests keep passing.
+
+**Tech Stack:** React, CSS Modules, Vitest + Testing Library, Vite (`apps/web`). Spec: `docs/superpowers/specs/2026-09-06-linear-dark-kanban-design.md`.
+
+**Out of scope:** Issue list, command palette, Trash view, URL state, CLI/Rust/API, new font npm packages.
+
+**Verify always:** `pnpm --filter @taskboard/ui test` (28 tests today). After UI CSS/JS: `pnpm --filter web build`.
+
+---
+
+## File map
+
+- Modify: `apps/web/index.html` — Inter `<link>`, `color-scheme` on `<html>`
+- Modify: `packages/ui/src/theme.css` — Linear-dark tokens + Inter stack
+- Modify: `packages/ui/src/Card.module.css` — flat cards, no glass/shadow
+- Modify: `packages/ui/src/Board.module.css` — dark columns, 8px radius
+- Modify: `packages/ui/src/Sidebar.module.css` — hairline, no extra hex
+- Modify: `packages/ui/src/Search.module.css` — dark field
+- Modify: `packages/ui/src/Inspector.module.css` — overlay panel + backdrop
+- Modify: `packages/ui/src/TaskboardApp.module.css` — always 2-column shell
+- Modify: `packages/ui/src/TaskboardApp.tsx` — overlay dismiss handler
+- Modify: `packages/ui/src/Inspector.tsx` — backdrop, `onClose`
+- Modify: `packages/ui/src/inspector-design.test.tsx` — overlay tests
+
+Do not split files. Do not add list view components.
+
+---
+
+### Task 1: Inter and dark tokens
+
+**Files:**
+- Modify: `apps/web/index.html`
+- Modify: `packages/ui/src/theme.css`
+- Test: `packages/ui/src/inspector-design.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/ui/src/inspector-design.test.tsx`:
+
+```tsx
+  it("uses a dark color-scheme on the document", async () => {
+    const transport = fakeTransport();
+    await transport.projectAdd({ name: "Untitled" });
+    render(<TaskboardApp transport={transport} />);
+    await screen.findByRole("list", { name: "Todo" });
+    const scheme = getComputedStyle(document.documentElement).colorScheme;
+    expect(scheme).toMatch(/dark/);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @taskboard/ui test -- src/inspector-design.test.tsx`
+
+Expected: FAIL — `colorScheme` is `normal` or empty (theme.css has no `color-scheme: dark`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `apps/web/index.html` with:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;650&display=swap"
+      rel="stylesheet"
+    />
+    <title>Taskboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+Replace `packages/ui/src/theme.css` with:
+
+```css
+:root {
+  --sidebar-bg: #0c0d0e;
+  --board-bg: #08090a;
+  --accent: #5e6ad2;
+  --accent-2: #5e6ad2;
+  --urgent: #e24a2b;
+  --waiting: #d89a1a;
+  --completed: #2f9e62;
+  --running: #5e6ad2;
+  --sidebar-fg: #e8e8ec;
+  --sidebar-muted: #8a8f98;
+  --board-fg: #e8e8ec;
+  --card-bg: #16171a;
+  --card-border: #23242a;
+  --failed: #c45c4a;
+  --panel-bg: #101113;
+  --hairline: #1b1c1f;
+  --font: Inter, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: var(--font);
+  background: var(--board-bg);
+  color: var(--board-fg);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent-2);
+  outline-offset: 2px;
+}
+```
+
+In `packages/ui/src/TaskboardApp.module.css`, change `.app` `font-family` to `var(--font)`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @taskboard/ui test`
+
+Expected: PASS (29 tests). If Inter weight `650` 404s in the browser later, drop it to `600` in the Google Fonts URL only — do not add an npm font package.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/index.html packages/ui/src/theme.css packages/ui/src/TaskboardApp.module.css packages/ui/src/inspector-design.test.tsx
+git commit -m "style: Linear-dark tokens and Inter"
+```
+
+---
+
+### Task 2: Flat cards
+
+**Files:**
+- Modify: `packages/ui/src/Card.module.css`
+- Test: `packages/ui/src/Card.test.tsx` (run only; do not change assertions)
+
+- [ ] **Step 1: Run existing card tests as baseline**
+
+Run: `pnpm --filter @taskboard/ui test -- src/Card.test.tsx`
+
+Expected: PASS (4 tests). These cover badges, ids, lift placeholder — not shadows.
+
+- [ ] **Step 2: Flatten card chrome**
+
+Replace `packages/ui/src/Card.module.css` with:
+
+```css
+.card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto auto;
+  gap: 0.2rem 0.5rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 6px;
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  color: var(--board-fg);
+  cursor: grab;
+  box-shadow: none;
+}
+
+.card:active {
+  cursor: grabbing;
+}
+
+.placeholder {
+  opacity: 0.4;
+  box-shadow: none;
+}
+
+.lifted {
+  cursor: grabbing;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  transform: rotate(1.5deg) scale(1.03);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lifted {
+    transform: none;
+  }
+}
+
+.card[aria-selected="true"] {
+  border-color: var(--accent);
+  box-shadow: none;
+}
+
+.card.lifted[aria-selected="true"] {
+  border-color: var(--accent);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.title {
+  grid-column: 1;
+  font-weight: 500;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.displayId {
+  grid-column: 1;
+  color: var(--sidebar-muted);
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+
+.meta {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--urgent);
+}
+
+.badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 0.12rem 0.4rem;
+  border-radius: 999px;
+  color: #fff;
+}
+
+.waiting {
+  background: var(--waiting);
+}
+
+.running {
+  background: var(--running);
+}
+
+.failed {
+  background: var(--failed);
+}
+
+.completed {
+  background: var(--completed);
+}
+
+.runMessage {
+  grid-column: 1 / -1;
+  font-size: 0.75rem;
+  color: var(--sidebar-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+```
+
+No `backdrop-filter`. Selected = 1px accent border only. Lift shadow is allowed on the drag overlay only.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pnpm --filter @taskboard/ui test -- src/Card.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/Card.module.css
+git commit -m "style: flatten Kanban cards to Linear-dark"
+```
+
+---
+
+### Task 3: Dark board, sidebar, search
+
+**Files:**
+- Modify: `packages/ui/src/Board.module.css`
+- Modify: `packages/ui/src/Sidebar.module.css`
+- Modify: `packages/ui/src/Search.module.css`
+
+- [ ] **Step 1: Run UI tests as baseline**
+
+Run: `pnpm --filter @taskboard/ui test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Restyle board columns and search hint**
+
+In `packages/ui/src/Board.module.css`:
+
+- `.column`: `border-radius: 8px; background: var(--panel-bg); border: 1px solid var(--hairline);` — delete the `color-mix(..., #fff 55%, ...)` background.
+- `.header`: `color: var(--sidebar-muted); font-weight: 500;`
+- `.count`: `color: var(--sidebar-muted);`
+- `.slot`: `border-radius: 6px;`
+- `.searchHint`: `background: var(--panel-bg); color: var(--sidebar-muted); border-color: var(--hairline);` — no `#fff` mix.
+- `.columnCurrent`: keep inset accent ring via `box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);`
+
+In `packages/ui/src/Search.module.css` keep structure; ensure `background: var(--card-bg); border-color: var(--hairline); color: var(--board-fg);`
+
+In `packages/ui/src/Sidebar.module.css`:
+
+- `.note textarea`: `border: 1px solid var(--hairline); background: var(--board-bg);` — delete `color-mix(..., #fff ...)`.
+- `.newProject` / `.project[aria-current="true"]` already use `var(--accent)`; leave behavior, keep `min-height: 44px`.
+- `.toggle[aria-pressed="true"]`: `color: var(--accent);`
+
+Do not add new hex except through tokens already in `theme.css`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pnpm --filter @taskboard/ui test`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/Board.module.css packages/ui/src/Sidebar.module.css packages/ui/src/Search.module.css
+git commit -m "style: dark board columns and sidebar hairlines"
+```
+
+---
+
+### Task 4: Overlay inspector
+
+**Files:**
+- Modify: `packages/ui/src/TaskboardApp.module.css`
+- Modify: `packages/ui/src/TaskboardApp.tsx`
+- Modify: `packages/ui/src/Inspector.tsx`
+- Modify: `packages/ui/src/Inspector.module.css`
+- Test: `packages/ui/src/inspector-design.test.tsx`
+
+Behavior:
+
+- Shell is always `240px + 1fr`. Board never shrinks for details.
+- Empty inspector (`open && !task`) stays mounted with “Select a card” and `display: none`.
+- Open inspector (`open && task`) is `position: fixed` width `360px`, right/top/bottom 12px, z-index 20.
+- Backdrop button `aria-label="Dismiss details"` sits under the panel; click calls `onClose`.
+- Escape already sets `inspectorOpen` false in `TaskboardApp` — keep it.
+- Overlay transition `transform/opacity` 180ms ease-out; `@media (prefers-reduced-motion: reduce) { transition: none }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/ui/src/inspector-design.test.tsx`:
+
+```tsx
+  it("keeps four columns visible while the inspector is open", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Keep columns", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByRole("listitem", { name: /Keep columns/ }));
+    expect(await screen.findByLabelText("Title")).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Todo" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "In Progress" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "In Review" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Done" })).toBeTruthy();
+  });
+
+  it("closes the inspector when dismiss is clicked", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Closable", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByRole("listitem", { name: /Closable/ }));
+    expect(await screen.findByLabelText("Title")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss details" }));
+    expect(screen.queryByLabelText("Title")).toBeNull();
+    expect(screen.getByText("Select a card")).toBeTruthy();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @taskboard/ui test -- src/inspector-design.test.tsx`
+
+Expected: first new test may pass today (columns exist even when grid is 3-col). Second test FAIL — no `Dismiss details` button.
+
+If the four-column test passes before overlay work, keep it as a regression. The dismiss test is the red bar for this task.
+
+- [ ] **Step 3: Overlay CSS**
+
+Replace `packages/ui/src/TaskboardApp.module.css` with:
+
+```css
+.app {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  min-height: 100vh;
+  font-family: var(--font);
+  background: var(--board-bg);
+  position: relative;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 0.9rem 1rem 1.25rem;
+  overflow: auto;
+}
+
+@media (max-width: 800px) {
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+}
+```
+
+Delete `.collapsed` and `.collapsed > aside:last-child`. The 3-column template must not return.
+
+Replace overlay-related rules in `packages/ui/src/Inspector.module.css` (keep `.field`, `.note`, `.delete`, `.deleteRow`, `.cancel` as they are, but retarget colors to tokens). Put these at the top of the file, replacing `.panel` and `.empty`:
+
+```css
+.backdrop {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  z-index: 15;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  width: 360px;
+  max-width: calc(100vw - 24px);
+  padding: 1rem 1rem 1.25rem;
+  background: var(--panel-bg);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  color: var(--board-fg);
+  overflow: auto;
+  z-index: 20;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  transition: opacity 180ms ease-out, transform 180ms ease-out;
+  transform: translateX(0);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    transition: none;
+  }
+}
+```
+
+Also change `.field input/select/textarea` `background` to `var(--card-bg)` and `border-color` to `var(--hairline)`. Change `.heading` / `.displayId` muted color to `var(--sidebar-muted)`.
+
+- [ ] **Step 4: Overlay markup**
+
+In `packages/ui/src/Inspector.tsx`, add `onClose?: () => void` to props.
+
+Replace the empty-task return:
+
+```tsx
+  if (!props.task) {
+    return (
+      <aside className={`${styles.panel} ${styles.hidden}`}>
+        <div className={styles.empty}>
+          <EmptyState>Select a card</EmptyState>
+        </div>
+      </aside>
+    );
+  }
+```
+
+Replace the populated return wrapper with:
+
+```tsx
+  return (
+    <>
+      <button
+        type="button"
+        className={styles.backdrop}
+        aria-label="Dismiss details"
+        onClick={() => props.onClose?.()}
+      />
+      <aside className={styles.panel} role="dialog" aria-label="Task details">
+```
+
+Close with `</aside></>` instead of a single `</aside>`.
+
+Do not remove delete confirm (`Move to Trash` / `Cancel`).
+
+In `packages/ui/src/TaskboardApp.tsx`:
+
+1. Change the shell className from `` `${styles.app} ${inspectorOpen && detail ? "" : styles.collapsed}` `` to `styles.app`.
+2. Pass `onClose` into `Inspector`:
+
+```tsx
+        onClose={() => {
+          setInspectorOpen(false);
+          inspectorOpenRef.current = false;
+        }}
+```
+
+Keep `open={inspectorOpen}` so Escape still unmounts via `if (!props.open) return null`. When Escape fires, “Select a card” disappears until the next project apply sets `inspectorOpen` true again — that matches `keyboard.test.tsx` (“Select a card” is null while a titled inspector is open). After dismiss click, `open` is false so “Select a card” is also null unless we keep `open` true.
+
+**Dismiss vs Escape:** Spec wants click-away to close. Existing Escape sets `open` false. For the dismiss test `getByText("Select a card")` after click, `onClose` must hide the dialog but keep `open` true with `detail` cleared, OR keep `open` true and only clear selection.
+
+Use this `onClose` so the empty hidden node remains (matches the dismiss test and Board.test on later project select):
+
+```tsx
+        onClose={() => {
+          setSelectedId(null);
+          selectedIdRef.current = null;
+          applyDetail(null);
+          setInspectorOpen(true);
+          inspectorOpenRef.current = true;
+        }}
+```
+
+Escape in `TaskboardApp` currently only sets `inspectorOpen` false and does not clear `detail`. Leave Escape as-is (keyboard test). Dismiss click uses `onClose` above.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm --filter @taskboard/ui test`
+
+Expected: PASS, including new overlay tests and existing `shows inspector empty copy until a card is selected`.
+
+If `role="dialog"` breaks a query, drop `role="dialog"` and keep `aria-label` on the aside only.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/TaskboardApp.tsx packages/ui/src/TaskboardApp.module.css packages/ui/src/Inspector.tsx packages/ui/src/Inspector.module.css packages/ui/src/inspector-design.test.tsx
+git commit -m "feat: overlay task inspector on the full-width board"
+```
+
+---
+
+### Task 5: Dist build
+
+**Files:** none in git except whatever Task 1–4 already committed. `apps/web/dist` is gitignored.
+
+- [ ] **Step 1: Build web**
+
+Run: `pnpm --filter web build`
+
+Expected: Vite success, CSS/JS hashed into `apps/web/dist`.
+
+- [ ] **Step 2: Smoke the live UI**
+
+If `task start` / `tb serve` is running, reload `http://127.0.0.1:<port>/`. Check: dark board, 4 columns with no card selected, overlay on click, Escape and dismiss close it, New task still works, delete still confirms.
+
+No extra commit unless the smoke forces a one-line CSS fix. If you fix, commit `style: Linear-dark smoke fix` with only that file.
+
+---
+
+## Spec coverage
+
+| Spec section | Task |
+|--------------|------|
+| §3 tokens, Inter, color-scheme, no glass | 1, 2, 3 |
+| §4 cards, 4 columns, no inspector when empty | 2, 4 |
+| §5 overlay 360px, Escape, click-away, reduced motion, delete confirm | 4 |
+| §6 keep shortcuts / skip list, palette, Trash, URL | constraints (no tasks) |
+| §8 tests + web build | 4, 5 |
+
+## Placeholder scan
+
+No TBD. Overlay dismiss vs Escape is specified in Task 4. Font CDN is Google Fonts `<link>` only, no npm package.

--- a/docs/superpowers/specs/2026-09-06-linear-dark-kanban-design.md
+++ b/docs/superpowers/specs/2026-09-06-linear-dark-kanban-design.md
@@ -1,0 +1,102 @@
+# Linear 風ダーク Kanban
+
+日付: 2026-09-06  
+対象: localhost web UI と、同じ `packages/ui` を使う Tauri デスクトップ  
+親スペック: `docs/superpowers/specs/2026-09-05-local-taskboard-design.md`
+
+この文書は、親スペックの **§6 Visual design（Native Glass）** を UI 表面について置き換える。ドメイン、4列、CLI、キーボード契約は親のまま。
+
+## 1. 要約
+
+Taskboard のボードを Linear のボード言語に寄せる。面はほぼ黒、境界はヘアライン、字は Inter、アクセントのインディゴは選択と主ボタンだけ。カード詳細は右カラムではなく、全幅ボードの上に乗るオーバーレイにする。
+
+Issue リスト、コマンドパレット、Trash 画面、URL への状態保存は作らない。Linear のクローンではない。
+
+## 2. 決まったこと
+
+| 項目 | 決定 |
+|------|------|
+| 面 | Linear dark（ほぼ黒） |
+| ホーム | 4列 Kanban のまま |
+| 詳細 | 右から被さるオーバーレイ |
+| 深さ | Linear のボード言語（トークン＋カード＋オーバーレイ）。製品クローンではない |
+
+## 3. 面とタイポ
+
+| 役割 | 値 |
+|------|-----|
+| ワークスペース | `#08090a` |
+| サイドバー | `#0c0d0e` |
+| カラム／パネル | `#101113` |
+| カード | `#16171a` |
+| ヘアライン | `#1b1c1f` / `#23242a` |
+| 本文 | `#e8e8ec` |
+| ミュート | `#8a8f98` |
+| アクセント | `#5e6ad2`（主ボタンと選択ボーダーだけ） |
+| Urgent | 親スペックどおりオレンジレッド |
+| 完了 / 失敗 | 親スペックの緑 / 赤 |
+
+- フォント: Inter。フォールバックは `"SF Pro Text", system-ui, sans-serif`。
+- `html` に `color-scheme: dark`。
+- ガラス、ラベンダーのボード、カードのドロップシャドウは使わない。
+- 角丸は 6–8px。大きく膨らませない。
+
+トークンは `packages/ui/src/theme.css` の CSS 変数に集約する。コンポーネントへ hex を散らさない。
+
+## 4. ボードとカード
+
+- 列: Todo / In Progress / In Review / Done。ラベルと件数はミュート。
+- カード: タイトル、その下に `TASK-n`（tabular-nums）とステータスピル。影なし。選択中は 1px のインディゴボーダー。
+- 空列: 破線スロットのままでよい。列ごとの「追加」ボタンは今回やらない。ツールバーの New task が入口。
+- 未選択時はインスペクタを出さない。ボードはビューポート幅いっぱい。
+
+## 5. オーバーレイ
+
+- 幅およそ 360px。ボードは縮まない。パネルが右から乗る。
+- 開く: カード選択。閉じる: Escape、パネル外クリック、選択解除。別カードを選ぶと中身だけ差し替え。
+- 中身: タイトル、`TASK-n`、列、Urgent、ノート、Links / Runs / Activity、削除確認（Delete → Move to Trash / Cancel）。
+- 動き: 150–200ms ease-out。`prefers-reduced-motion: reduce` ならトランジションなし。
+- フォーカスはパネル内に置く。閉じたらボードへ戻す。
+
+実装は既存の `inspectorOpen && detail` を、グリッド第3列ではなく `position` オーバーレイにする。空の「Select a card」パネルは出さない（テストが DOM 上の文言を探すなら、非表示ノードとして残してよい）。
+
+## 6. 残すもの / やらないもの
+
+**残す**
+
+- 4列と DnD（リフト、スナップバックなし）。
+- ショートカット: `n` `/` `j` `k` `h` `l` `1–4` Escape、New task、ワードマーク、検索の `/` ヒント。
+- 削除の二段確認。
+- アクティビティは人間向けラベル（Moved など）。
+
+**やらない**
+
+- Issue リスト、ボード／リストのビュー切替。
+- コマンドパレット。
+- Trash の実画面（ボタンは今どおり死んでいる。別タスク）。
+- URL にプロジェクトやカードを載せる。
+- Native Glass のラベンダー面とガラスカード。
+
+## 7. 触るファイル
+
+- `packages/ui/src/theme.css` — トークン、フォント、`color-scheme`
+- `packages/ui/src/*.module.css` — 面、境界、密度
+- `packages/ui/src/TaskboardApp.tsx` / `.module.css` — オーバーレイ配置
+- `packages/ui/src/Inspector.tsx` / `.module.css` — パネル見た目（確認フローは維持）
+- `packages/ui/src/Card.module.css` — フラットカード
+- `apps/web/index.html` — Inter を `<link>` で1本読む。`packages/ui` の `font-family` がそれを使う。新しいフォントパッケージは足さない。
+
+CLI、Rust ドメイン、HTTP API は触らない。
+
+## 8. 検証
+
+- `pnpm --filter @taskboard/ui test` が緑。既存の「Select a card」アサーションを壊さない。
+- 1440px: 未選択で4列が揃う。選択でボード幅が潰れない。
+- Escape とパネル外クリックでオーバーレイが閉じる。
+- 削除は確認なしに走らない。
+- `prefers-reduced-motion` でオーバーレイが跳ねない。
+- 実装後に `pnpm --filter web build`（`tb serve` は dist を見る）。
+
+## 9. 成功条件
+
+暗い Linear のボードに見える。カードを開いても4列が消えず、詳細は上に乗る。ショートカットと DnD は今と同じ。リスト画面は増えない。

--- a/packages/ui/src/Board.module.css
+++ b/packages/ui/src/Board.module.css
@@ -27,9 +27,9 @@
   transform: translateY(-50%);
   padding: 0.1rem 0.4rem;
   border-radius: 6px;
-  border: 1px solid var(--card-border);
-  background: color-mix(in srgb, #fff 70%, var(--board-bg));
-  color: color-mix(in srgb, var(--board-fg) 55%, transparent);
+  border: 1px solid var(--hairline);
+  background: var(--panel-bg);
+  color: var(--sidebar-muted);
   font: inherit;
   font-size: 0.75rem;
   line-height: 1;
@@ -64,10 +64,10 @@
   display: flex;
   flex-direction: column;
   min-height: 12rem;
-  border-radius: 16px;
+  border-radius: 8px;
   padding: 0.75rem;
-  background: color-mix(in srgb, #fff 55%, var(--board-bg));
-  border: 1px solid var(--card-border);
+  background: var(--panel-bg);
+  border: 1px solid var(--hairline);
 }
 
 .columnCurrent {
@@ -80,11 +80,12 @@
   justify-content: space-between;
   margin: 0 0 0.65rem;
   font-size: 0.8rem;
-  font-weight: 650;
+  font-weight: 500;
+  color: var(--sidebar-muted);
 }
 
 .count {
-  color: color-mix(in srgb, var(--board-fg) 50%, transparent);
+  color: var(--sidebar-muted);
   font-variant-numeric: tabular-nums;
 }
 
@@ -101,5 +102,5 @@
   flex: 1;
   min-height: 4.5rem;
   border: 1px dashed color-mix(in srgb, var(--board-fg) 18%, transparent);
-  border-radius: 12px;
+  border-radius: 6px;
 }

--- a/packages/ui/src/Card.module.css
+++ b/packages/ui/src/Card.module.css
@@ -3,14 +3,13 @@
   grid-template-columns: 1fr auto;
   grid-template-rows: auto auto auto;
   gap: 0.2rem 0.5rem;
-  padding: 0.7rem 0.8rem;
-  border-radius: 12px;
+  padding: 0.6rem 0.7rem;
+  border-radius: 6px;
   border: 1px solid var(--card-border);
   background: var(--card-bg);
-  backdrop-filter: blur(16px);
   color: var(--board-fg);
   cursor: grab;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.7) inset, 0 8px 20px rgba(28, 27, 34, 0.04);
+  box-shadow: none;
 }
 
 .card:active {
@@ -24,9 +23,7 @@
 
 .lifted {
   cursor: grabbing;
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.75) inset,
-    0 18px 40px rgba(28, 27, 34, 0.22);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
   transform: rotate(1.5deg) scale(1.03);
 }
 
@@ -38,19 +35,18 @@
 
 .card[aria-selected="true"] {
   border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
+  box-shadow: none;
 }
 
 .card.lifted[aria-selected="true"] {
-  box-shadow:
-    0 0 0 1px var(--accent),
-    0 18px 40px rgba(28, 27, 34, 0.22);
+  border-color: var(--accent);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
 }
 
 .title {
   grid-column: 1;
-  font-weight: 600;
-  font-size: 0.9rem;
+  font-weight: 500;
+  font-size: 0.875rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -58,9 +54,10 @@
 
 .displayId {
   grid-column: 1;
-  color: color-mix(in srgb, var(--board-fg) 55%, transparent);
+  color: var(--sidebar-muted);
   font-size: 0.72rem;
-  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
 }
 
 .meta {
@@ -81,8 +78,8 @@
 
 .badge {
   font-size: 0.65rem;
-  font-weight: 650;
-  letter-spacing: 0.02em;
+  font-weight: 600;
+  letter-spacing: 0;
   text-transform: none;
   padding: 0.12rem 0.4rem;
   border-radius: 999px;
@@ -108,7 +105,7 @@
 .runMessage {
   grid-column: 1 / -1;
   font-size: 0.75rem;
-  color: color-mix(in srgb, var(--board-fg) 62%, transparent);
+  color: var(--sidebar-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/ui/src/Inspector.module.css
+++ b/packages/ui/src/Inspector.module.css
@@ -1,17 +1,48 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  z-index: 15;
+}
+
 .panel {
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
-  height: 100%;
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  width: 360px;
+  max-width: calc(100vw - 24px);
   padding: 1rem 1rem 1.25rem;
-  background: color-mix(in srgb, #fff 70%, var(--board-bg));
-  border-left: 1px solid var(--card-border);
+  background: var(--panel-bg);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
   color: var(--board-fg);
   overflow: auto;
+  z-index: 20;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  transition: opacity 180ms ease-out, transform 180ms ease-out;
+  transform: translateX(0);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    transition: none;
+  }
 }
 
 .empty {
-  color: color-mix(in srgb, var(--board-fg) 55%, transparent);
+  color: var(--sidebar-muted);
 }
 
 .field {
@@ -28,7 +59,7 @@
   font: inherit;
   font-weight: 400;
   border-radius: 8px;
-  border: 1px solid var(--card-border);
+  border: 1px solid var(--hairline);
   background: var(--card-bg);
   color: var(--board-fg);
   padding: 0.4rem 0.5rem;
@@ -42,7 +73,7 @@
 .displayId {
   margin: 0;
   font-size: 0.8rem;
-  color: color-mix(in srgb, var(--board-fg) 55%, transparent);
+  color: var(--sidebar-muted);
 }
 
 .switch {
@@ -63,7 +94,7 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: color-mix(in srgb, var(--board-fg) 50%, transparent);
+  color: var(--sidebar-muted);
 }
 
 .delete {

--- a/packages/ui/src/Inspector.tsx
+++ b/packages/ui/src/Inspector.tsx
@@ -30,6 +30,7 @@ export function Inspector(props: {
   onUrgentChange: (urgent: boolean) => void;
   onNoteChange: (markdown: string) => void;
   onDelete: () => void;
+  onClose?: () => void;
 }) {
   const [title, setTitle] = useState(props.task?.title ?? "");
   const [note, setNote] = useState(props.task?.noteMarkdown ?? "");
@@ -64,7 +65,7 @@ export function Inspector(props: {
 
   if (!props.task) {
     return (
-      <aside className={styles.panel}>
+      <aside className={`${styles.panel} ${styles.hidden}`}>
         <div className={styles.empty}>
           <EmptyState>Select a card</EmptyState>
         </div>
@@ -76,89 +77,101 @@ export function Inspector(props: {
   const activities = [...props.task.recentActivities].sort((a, b) => b.sequence - a.sequence);
 
   return (
-    <aside className={styles.panel}>
-      <label className={styles.field}>
-        Title
-        <input
-          ref={props.titleRef}
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          onBlur={() => props.onTitleCommit(title)}
-        />
-      </label>
-      <p className={styles.displayId}>{props.task.displayId}</p>
-      <label className={styles.field}>
-        Column
-        <select
-          value={props.task.column}
-          onChange={(e) => props.onColumnChange(e.target.value as Column)}
-        >
-          {COLUMNS.map((col) => (
-            <option key={col.id} value={col.id}>
-              {col.label}
-            </option>
-          ))}
-        </select>
-      </label>
-      <label className={styles.switch}>
-        <input
-          type="checkbox"
-          checked={props.task.urgent}
-          onChange={(e) => props.onUrgentChange(e.target.checked)}
-        />
-        Urgent
-      </label>
-      <label className={styles.field}>
-        Note
-        <textarea
-          className={styles.note}
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-        />
-      </label>
-      <div>
-        <h3 className={styles.heading}>Links</h3>
-        <ul className={styles.list}>
-          {props.task.links.map((link) => (
-            <li key={link.id}>{link.value}</li>
-          ))}
-        </ul>
-      </div>
-      <div>
-        <h3 className={styles.heading}>Runs</h3>
-        <ul className={styles.list}>
-          {runs.map((run) => (
-            <li key={run.id}>
-              {run.displayId} {run.status}
-              {run.message ? ` — ${run.message}` : ""}
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div>
-        <h3 className={styles.heading}>Activity</h3>
-        <ul className={styles.list}>
-          {activities.map((item) => (
-            <li key={item.id}>
-              {activityLabel(item.operation)} · {item.actorLabel}
-            </li>
-          ))}
-        </ul>
-      </div>
-      {confirmDelete ? (
-        <div className={styles.deleteRow}>
-          <button type="button" className={styles.delete} onClick={props.onDelete}>
-            Move to Trash
-          </button>
-          <button type="button" className={styles.cancel} onClick={() => setConfirmDelete(false)}>
-            Cancel
-          </button>
+    <>
+      <button
+        type="button"
+        className={styles.backdrop}
+        aria-label="Dismiss details"
+        onClick={() => props.onClose?.()}
+      />
+      <aside className={styles.panel} role="dialog" aria-label="Task details">
+        <label className={styles.field}>
+          Title
+          <input
+            ref={props.titleRef}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onBlur={() => props.onTitleCommit(title)}
+          />
+        </label>
+        <p className={styles.displayId}>{props.task.displayId}</p>
+        <label className={styles.field}>
+          Column
+          <select
+            value={props.task.column}
+            onChange={(e) => props.onColumnChange(e.target.value as Column)}
+          >
+            {COLUMNS.map((col) => (
+              <option key={col.id} value={col.id}>
+                {col.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className={styles.switch}>
+          <input
+            type="checkbox"
+            checked={props.task.urgent}
+            onChange={(e) => props.onUrgentChange(e.target.checked)}
+          />
+          Urgent
+        </label>
+        <label className={styles.field}>
+          Note
+          <textarea
+            className={styles.note}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </label>
+        <div>
+          <h3 className={styles.heading}>Links</h3>
+          <ul className={styles.list}>
+            {props.task.links.map((link) => (
+              <li key={link.id}>{link.value}</li>
+            ))}
+          </ul>
         </div>
-      ) : (
-        <button type="button" className={styles.delete} onClick={() => setConfirmDelete(true)}>
-          Delete
-        </button>
-      )}
-    </aside>
+        <div>
+          <h3 className={styles.heading}>Runs</h3>
+          <ul className={styles.list}>
+            {runs.map((run) => (
+              <li key={run.id}>
+                {run.displayId} {run.status}
+                {run.message ? ` — ${run.message}` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className={styles.heading}>Activity</h3>
+          <ul className={styles.list}>
+            {activities.map((item) => (
+              <li key={item.id}>
+                {activityLabel(item.operation)} · {item.actorLabel}
+              </li>
+            ))}
+          </ul>
+        </div>
+        {confirmDelete ? (
+          <div className={styles.deleteRow}>
+            <button type="button" className={styles.delete} onClick={props.onDelete}>
+              Move to Trash
+            </button>
+            <button
+              type="button"
+              className={styles.cancel}
+              onClick={() => setConfirmDelete(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button type="button" className={styles.delete} onClick={() => setConfirmDelete(true)}>
+            Delete
+          </button>
+        )}
+      </aside>
+    </>
   );
 }

--- a/packages/ui/src/Inspector.tsx
+++ b/packages/ui/src/Inspector.tsx
@@ -84,7 +84,7 @@ export function Inspector(props: {
         aria-label="Dismiss details"
         onClick={() => props.onClose?.()}
       />
-      <aside className={styles.panel} role="dialog" aria-label="Task details">
+      <aside className={styles.panel} aria-label="Task details">
         <label className={styles.field}>
           Title
           <input

--- a/packages/ui/src/Search.module.css
+++ b/packages/ui/src/Search.module.css
@@ -1,7 +1,7 @@
 .input {
   width: 100%;
   max-width: none;
-  border: 1px solid var(--card-border);
+  border: 1px solid var(--hairline);
   border-radius: 10px;
   background: var(--card-bg);
   color: var(--board-fg);

--- a/packages/ui/src/Sidebar.module.css
+++ b/packages/ui/src/Sidebar.module.css
@@ -95,8 +95,8 @@
   min-height: 6.5rem;
   resize: vertical;
   border-radius: 10px;
-  border: 1px solid color-mix(in srgb, #fff 12%, transparent);
-  background: color-mix(in srgb, #fff 6%, transparent);
+  border: 1px solid var(--hairline);
+  background: var(--board-bg);
   color: var(--sidebar-fg);
   font: inherit;
   padding: 0.5rem;
@@ -116,7 +116,7 @@
 }
 
 .toggle[aria-pressed="true"] {
-  color: var(--accent-2);
+  color: var(--accent);
 }
 
 @media (max-width: 800px) {

--- a/packages/ui/src/TaskboardApp.module.css
+++ b/packages/ui/src/TaskboardApp.module.css
@@ -1,17 +1,10 @@
 .app {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr) minmax(320px, 420px);
+  grid-template-columns: 240px minmax(0, 1fr);
   min-height: 100vh;
   font-family: var(--font);
   background: var(--board-bg);
-}
-
-.collapsed {
-  grid-template-columns: 240px minmax(0, 1fr);
-}
-
-.collapsed > aside:last-child {
-  display: none;
+  position: relative;
 }
 
 .main {
@@ -23,9 +16,8 @@
 }
 
 @media (max-width: 800px) {
-  .app,
-  .collapsed {
+  .app {
     grid-template-columns: 1fr;
-    grid-template-rows: auto minmax(0, 1fr) auto;
+    grid-template-rows: auto minmax(0, 1fr);
   }
 }

--- a/packages/ui/src/TaskboardApp.module.css
+++ b/packages/ui/src/TaskboardApp.module.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: 240px minmax(0, 1fr) minmax(320px, 420px);
   min-height: 100vh;
-  font-family: "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  font-family: var(--font);
   background: var(--board-bg);
 }
 

--- a/packages/ui/src/TaskboardApp.tsx
+++ b/packages/ui/src/TaskboardApp.tsx
@@ -493,7 +493,7 @@ export function TaskboardApp(props: { transport: Transport; sequence?: number })
   }, [transport, applyProject]);
 
   return (
-    <div className={`${styles.app} ${inspectorOpen && detail ? "" : styles.collapsed}`}>
+    <div className={styles.app}>
       <Sidebar
         projects={projects}
         selectedSlug={selectedProject?.slug ?? null}
@@ -544,6 +544,13 @@ export function TaskboardApp(props: { transport: Transport; sequence?: number })
         }}
         onNoteChange={onNoteChange}
         onDelete={() => void onDelete()}
+        onClose={() => {
+          setSelectedId(null);
+          selectedIdRef.current = null;
+          applyDetail(null);
+          setInspectorOpen(true);
+          inspectorOpenRef.current = true;
+        }}
       />
     </div>
   );

--- a/packages/ui/src/inspector-design.test.tsx
+++ b/packages/ui/src/inspector-design.test.tsx
@@ -35,4 +35,29 @@ describe("design-review regressions", () => {
     const scheme = getComputedStyle(document.documentElement).colorScheme;
     expect(scheme).toMatch(/dark/);
   });
+
+  it("keeps four columns visible while the inspector is open", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Keep columns", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByRole("listitem", { name: /Keep columns/ }));
+    expect(await screen.findByLabelText("Title")).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Todo" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "In Progress" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "In Review" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Done" })).toBeTruthy();
+  });
+
+  it("closes the inspector when dismiss is clicked", async () => {
+    const transport = fakeTransport();
+    const project = await transport.projectAdd({ name: "Untitled" });
+    await transport.taskCreate(project.slug, { title: "Closable", column: "todo" });
+    render(<TaskboardApp transport={transport} />);
+    await userEvent.click(await screen.findByRole("listitem", { name: /Closable/ }));
+    expect(await screen.findByLabelText("Title")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss details" }));
+    expect(screen.queryByLabelText("Title")).toBeNull();
+    expect(screen.getByText("Select a card")).toBeTruthy();
+  });
 });

--- a/packages/ui/src/inspector-design.test.tsx
+++ b/packages/ui/src/inspector-design.test.tsx
@@ -26,4 +26,13 @@ describe("design-review regressions", () => {
     await userEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
     await waitFor(() => expect(transport.taskDelete).toHaveBeenCalled());
   });
+
+  it("uses a dark color-scheme on the document", async () => {
+    const transport = fakeTransport();
+    await transport.projectAdd({ name: "Untitled" });
+    render(<TaskboardApp transport={transport} />);
+    await screen.findByRole("list", { name: "Todo" });
+    const scheme = getComputedStyle(document.documentElement).colorScheme;
+    expect(scheme).toMatch(/dark/);
+  });
 });

--- a/packages/ui/src/theme.css
+++ b/packages/ui/src/theme.css
@@ -1,18 +1,21 @@
 :root {
-  --sidebar-bg: #1c1b22;
-  --board-bg: #f4f2f8;
-  --accent: #5b4bdb;
-  --accent-2: #7c6cff;
+  --sidebar-bg: #0c0d0e;
+  --board-bg: #08090a;
+  --accent: #5e6ad2;
+  --accent-2: #5e6ad2;
   --urgent: #e24a2b;
   --waiting: #d89a1a;
   --completed: #2f9e62;
-  --running: #5b4bdb;
-  --sidebar-fg: #f4f2f8;
-  --sidebar-muted: #a9a6b3;
-  --board-fg: #1c1b22;
-  --card-bg: rgba(255, 255, 255, 0.82);
-  --card-border: rgba(28, 27, 34, 0.08);
+  --running: #5e6ad2;
+  --sidebar-fg: #e8e8ec;
+  --sidebar-muted: #8a8f98;
+  --board-fg: #e8e8ec;
+  --card-bg: #16171a;
+  --card-border: #23242a;
   --failed: #c45c4a;
+  --panel-bg: #101113;
+  --hairline: #1b1c1f;
+  --font: Inter, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
 }
 
 *,
@@ -21,11 +24,15 @@
   box-sizing: border-box;
 }
 
+html {
+  color-scheme: dark;
+}
+
 html,
 body {
   margin: 0;
   min-height: 100%;
-  font-family: "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  font-family: var(--font);
   background: var(--board-bg);
   color: var(--board-fg);
 }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     jsx: "automatic",
   },
   test: {
+    css: true,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
   },


### PR DESCRIPTION
## Summary
- Restyle the local web/desktop UI to Linear-dark Kanban: near-black tokens, Inter, indigo only on primary actions and selection.
- Flatten cards (no glass; lift shadow on the drag overlay only) and restyle board, sidebar, and search to hairline dark surfaces.
- Move task details to a 360px overlay on a full-width 4-column board, with click-away dismiss and existing Escape close. Load Inter in both the web and Tauri shells.

## Test plan
- [ ] `pnpm --filter @taskboard/ui test` (31 tests)
- [ ] Reload `tb serve` / `task start` after `pnpm --filter web build`
- [ ] Empty board shows 4 columns and no inspector panel
- [ ] Click a card: overlay opens, board stays full width, 4 columns remain
- [ ] Click backdrop ("Dismiss details") closes the overlay; Escape also closes it
- [ ] New task still creates a card and opens details
- [ ] Delete still requires Move to Trash / Cancel


Made with [Cursor](https://cursor.com)